### PR TITLE
fix(nextjs): allow typed NextConfig in withDualmark()

### DIFF
--- a/.changeset/fix-with-dualmark-types.md
+++ b/.changeset/fix-with-dualmark-types.md
@@ -1,0 +1,20 @@
+---
+"@dualmark/nextjs": patch
+---
+
+Fix `withDualmark()` rejecting typed `NextConfig` from `next.config.ts`.
+
+The internal `NextConfigShape` constraint had an `[key: string]: unknown` index
+signature, which TypeScript treats as a structural demand on the input. Next.js's
+`NextConfig` is a closed interface with no top-level index signature, so any
+caller passing a typed `next.config.ts` hit:
+
+```
+Type 'NextConfig' is not assignable to type 'NextConfigShape'.
+  Index signature for type 'string' is missing in type 'NextConfig'.
+```
+
+The constraint was unnecessary — the function only reads `transpilePackages`
+and spreads the remaining config, neither of which need an index signature.
+Removing it unblocks typed configs on Next 14, 15, and 16. Runtime behavior
+is unchanged.

--- a/packages/nextjs/src/with-dualmark.ts
+++ b/packages/nextjs/src/with-dualmark.ts
@@ -3,7 +3,6 @@ import type { DualmarkNextConfig } from "./types.js";
 
 interface NextConfigShape {
   transpilePackages?: string[];
-  [key: string]: unknown;
 }
 
 const REQUIRED_TRANSPILE = ["@dualmark/core", "@dualmark/converters", "@dualmark/nextjs"] as const;


### PR DESCRIPTION
## Summary

The `[key: string]: unknown` index signature on `NextConfigShape` made `T extends NextConfigShape` reject any caller passing Next's typed `NextConfig` (a closed interface with no top-level index signature), breaking type-checking in `next.config.ts`

The constraint is unnecessary - the function only reads `transpilePackages` and spreads `...base`, neither of which need an index signature. Removing it is strictly more permissive and unblocks typed configs without changing runtime behavior.

## Type

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Spec change (requires bump in `AEO_SPEC_VERSION`)
- [ ] Docs / examples / tooling only

## Verification

- [x] `bun run build` passes
- [x] `bun run test` passes
- [x] `bun run typecheck` passes
- [x] If touching examples: ran `dualmark verify` against the example end-to-end
- [x] If touching `/spec/`: ran `bun run --filter dualmark-docs sync-spec` and committed the mirror

## Changeset

- [ ] Added a changeset (`bun run changeset`) for any package with a user-visible change
