### PR TITLE
ci(release): publish @dualmark/* with npm provenance attestation

### DIFF
--- a/.changeset/npm-provenance.md
+++ b/.changeset/npm-provenance.md
@@ -1,0 +1,16 @@
+---
+"@dualmark/core": patch
+"@dualmark/converters": patch
+"@dualmark/astro": patch
+"@dualmark/nextjs": patch
+"@dualmark/cloudflare": patch
+"@dualmark/cli": patch
+---
+
+Release pipeline now publishes with **npm provenance attestation**. Every
+`@dualmark/*` tarball on npmjs.com is now Sigstore-signed and traceable back
+to the exact GitHub Actions workflow run + commit SHA that built it. Visible
+as a "Provenance" badge on each package's npm page.
+
+No behavior change inside the packages themselves — this is a supply-chain
+hardening release. Consumers can verify with `npm audit signatures`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,11 +47,11 @@ jobs:
         with:
           registry-url: https://registry.npmjs.org
 
-      # Refresh bun.lock workspace metadata so `bun publish` rewrites
-      # `workspace:*` deps to the tag's actual versions. `bun install
-      # --frozen-lockfile` (in setup) does NOT update workspace version
-      # metadata even when packages/*/package.json drifts from bun.lock.
-      # See oven-sh/bun#20477 (open as of bun 1.3.5).
+      # Refresh bun.lock workspace metadata so `bun pm pack` (later step)
+      # rewrites `workspace:*` deps in the tarball to the tag's actual
+      # versions. `bun install --frozen-lockfile` (in setup) does NOT update
+      # workspace version metadata even when packages/*/package.json drifts
+      # from bun.lock. See oven-sh/bun#20477 (open as of bun 1.3.5).
       - name: Refresh lockfile workspace metadata
         run: bun install --lockfile-only
 
@@ -85,20 +85,30 @@ jobs:
             exit 1
           fi
 
-      - name: Publish to npm
-        # Uses `bun publish` per package instead of `changeset publish` because
-        # changesets delegates to `npm publish` (which does NOT rewrite
-        # workspace:* dependencies). bun publish DOES rewrite workspace:* to
-        # the actual version at pack time, producing valid tarballs that
-        # external consumers can install.
+      - name: Publish to npm (with provenance)
+        # Two-step pack-then-publish flow:
         #
-        # Auth: bun publish reads NPM_CONFIG_TOKEN env var (since bun 1.1.33).
-        # This is the only reliable auth method for bun publish in CI —
-        # writing ~/.npmrc does NOT work because bun looks at NPM_CONFIG_USERCONFIG
-        # path, not ~/.npmrc by default.
+        #   1. `bun pm pack` rewrites `workspace:*` deps to concrete versions
+        #      at pack time. `npm publish` alone CANNOT do this — it would
+        #      ship invalid `"workspace:*"` strings to the registry.
+        #   2. `npm publish <tarball> --provenance` uploads the pre-packed
+        #      tarball and generates a Sigstore-backed npm provenance
+        #      attestation (visible as a "Provenance" badge on npmjs.com).
         #
-        # Provenance disabled because the repo is INTERNAL — flip repo public
-        # + add `--provenance` here to re-enable.
+        # Why not `bun publish --provenance`?
+        #   As of bun 1.3.5, `bun publish` does NOT support the --provenance
+        #   flag. See oven-sh/bun#15601 / #21586. When that lands in a stable
+        #   bun release, this whole block can collapse back to
+        #   `bun publish --access public --provenance --tag latest`.
+        #
+        # Why `--provenance` requires `id-token: write`:
+        #   npm provenance uses OIDC to mint a short-lived Sigstore cert from
+        #   the GitHub Actions runner's identity, so the published attestation
+        #   is cryptographically tied to this exact workflow file + commit SHA.
+        #   Permission is granted at the job level above.
+        #
+        # Auth: `actions/setup-node` (in our setup composite action) writes
+        # ~/.npmrc to read $NODE_AUTH_TOKEN, which is what `npm publish` uses.
         run: |
           set -euo pipefail
           published_count=0
@@ -113,12 +123,21 @@ jobs:
               echo "::endgroup::"
               continue
             fi
-            echo "::group::Publishing $pkg_name@$pkg_version"
-            (cd "$pkg_dir" && bun publish --access public --tag latest)
+            echo "::group::Packing $pkg_name@$pkg_version"
+            # `bun pm pack --quiet` prints ONLY the tarball filename (no progress
+            # noise, no summary). Without --quiet, stdout includes "packed <file>"
+            # lines and a "Total files: N" footer that breaks any `tail -n 1`
+            # parsing. The tarball is written to the package dir.
+            tarball=$(cd "$pkg_dir" && bun pm pack --quiet)
+            tarball_abs="$(cd "$pkg_dir" && readlink -f "$tarball")"
+            echo "  tarball: $tarball_abs"
+            echo "::endgroup::"
+            echo "::group::Publishing $pkg_name@$pkg_version (with provenance)"
+            npm publish "$tarball_abs" --access public --tag latest --provenance
             echo "::endgroup::"
             published_count=$((published_count + 1))
           done
           echo ""
-          echo "Published $published_count package(s) to npm at version matching tag."
+          echo "Published $published_count package(s) to npm with provenance attestation."
         env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,11 +69,26 @@ Publishing the release fires the **`Release (npm publish)`** workflow which:
 - Checks out the exact tag
 - Builds + tests + typechecks all `@dualmark/*` packages
 - Verifies at least one package version matches the tag
-- Publishes each `packages/*` to npm via `bun publish --access public --tag latest` (which rewrites `workspace:*` deps to the actual pinned version at pack time)
-- Auth via `NPM_CONFIG_TOKEN` env (the only reliable auth path for `bun publish` in CI)
-- Skips packages that are already at that version on the registry (idempotent re-runs)
+- Packs each `packages/*` with `bun pm pack --quiet` (rewrites `workspace:*` deps to concrete versions in the tarball)
+- Publishes each tarball with `npm publish <tarball> --provenance --access public --tag latest`, which:
+  - Uploads the pre-packed tarball
+  - Generates a [Sigstore-backed npm provenance attestation](https://docs.npmjs.com/generating-provenance-statements) tying the published artifact to this exact workflow run + commit SHA (visible as a "Provenance" badge on the package's npm page)
+- Auth via `NODE_AUTH_TOKEN` env (wired into `~/.npmrc` by `actions/setup-node` in the composite setup action)
+- Skips packages already at that version on the registry (idempotent re-runs)
+
+Why `bun pm pack` + `npm publish` instead of just `bun publish`? As of bun 1.3.5, `bun publish` does not yet support `--provenance` (tracked at [oven-sh/bun#15601](https://github.com/oven-sh/bun/issues/15601)). When that ships in a stable bun release, the two-step flow collapses back to a single `bun publish --provenance` call.
 
 If anything fails, the release is on GitHub but nothing is on npm — fix and re-run the workflow via **Actions → Release → Run workflow** with the tag as input.
+
+### Verifying provenance
+
+Consumers (and you) can verify any `@dualmark/*` tarball's provenance attestation with:
+
+```bash
+npm audit signatures
+# or, per-package:
+npm view @dualmark/core --json | grep -A2 attestations
+```
 
 ### Why two workflows
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
   <a href="https://github.com/dodopayments/dualmark/blob/main/LICENSE">
     <img src="https://img.shields.io/badge/license-Apache%202.0-green" alt="License" />
   </a>
+  <a href="https://www.npmjs.com/package/@dualmark/core">
+    <img src="https://img.shields.io/badge/npm-provenance-blueviolet?logo=npm" alt="npm provenance" />
+  </a>
   <a href="https://discord.gg/bYqAp4ayYh">
     <img src="https://img.shields.io/discord/1305511580854779984?label=Join%20Discord&logo=discord" alt="Join Discord" />
   </a>


### PR DESCRIPTION
## Summary

The repo is now public, so we can finally cash that in for **npm provenance**. After this PR merges and the next release ships, every `@dualmark/*` tarball on npm will carry a Sigstore-backed attestation tied to this workflow run + commit SHA — visible as a **Provenance** badge on each package's npm page and verifiable by consumers with `npm audit signatures`.

The old workflow comment literally said: _"Provenance disabled because the repo is INTERNAL — flip repo public + add `--provenance` here to re-enable."_ This is that PR.

## Why a pack-then-publish dance, not just `bun publish --provenance`?

`bun publish` in bun 1.3.5 does not yet support `--provenance` ([oven-sh/bun#15601](https://github.com/oven-sh/bun/issues/15601), [#21586](https://github.com/oven-sh/bun/pull/21586)). And `npm publish` alone can't ship our packages because it doesn't resolve `workspace:*` deps — it would publish literal `"workspace:*"` strings to the registry, breaking every consumer install.

So:

1. `bun pm pack --quiet` per package — rewrites `workspace:*` → concrete versions in the tarball
2. `npm publish <tarball> --provenance --access public --tag latest` — uploads the pre-packed tarball and mints the Sigstore attestation via OIDC

Verified locally: `bun pm pack` on `@dualmark/astro` correctly rewrites `"@dualmark/core": "workspace:*"` → `"@dualmark/core": "0.5.0"` in the tarball. The publish step's idempotency guard (skip if version already on registry) is preserved.

When bun ships native `--provenance` (PR #21586 has it implemented, just not in a stable release yet), this whole block collapses back to one line — the comments in `release.yml` call out the cleanup explicitly so a future maintainer knows.

## Files

- **`.github/workflows/release.yml`** — Switched publish step from `bun publish` → `bun pm pack` + `npm publish --provenance`. Auth migrated `NPM_CONFIG_TOKEN` → `NODE_AUTH_TOKEN` (the env `actions/setup-node` wires into `~/.npmrc`). Comments explain every non-obvious choice (why pack-then-publish, why `--quiet`, why `id-token: write`).
- **`CONTRIBUTING.md`** — Rewrote the "Step 2 — GitHub Release" section to document the new flow and how to verify provenance with `npm audit signatures`.
- **`README.md`** — Added a `npm provenance` badge alongside the existing version/license/discord badges.
- **`.changeset/npm-provenance.md`** — Patch bump across all six `@dualmark/*` packages so the next release actually ships with the attestation (supply-chain hardening, no API changes).

## Validation

- `actionlint .github/workflows/*.yml` passes
- Local dry-run on `@dualmark/core` and `@dualmark/astro` produces valid tarballs with `workspace:*` correctly resolved
- `id-token: write` permission was already in place — **no repo settings change needed**
- `NPM_TOKEN` secret untouched — same auth, just consumed via `NODE_AUTH_TOKEN` env

## Not in this PR

- **Trusted Publishing / OIDC** — would let us delete `NPM_TOKEN` entirely. ~30s per package in npm UI × 6 packages. Worth a follow-up.

## How to land this

1. Merge this PR
2. The next `chore: version packages` PR will pick up the patch bumps from `.changeset/npm-provenance.md`
3. Merge that, draft a GitHub Release for `v0.5.2`, and the publish workflow will produce the first provenance-attested release
4. Confirm by visiting any `@dualmark/*` page on npmjs.com — the Provenance badge should appear