### PR TITLE
fix(ci): strip whitespace from `bun pm pack` output so npm publish doesn't ENOENT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,12 +124,20 @@ jobs:
               continue
             fi
             echo "::group::Packing $pkg_name@$pkg_version"
-            # `bun pm pack --quiet` prints ONLY the tarball filename (no progress
-            # noise, no summary). Without --quiet, stdout includes "packed <file>"
-            # lines and a "Total files: N" footer that breaks any `tail -n 1`
-            # parsing. The tarball is written to the package dir.
-            tarball=$(cd "$pkg_dir" && bun pm pack --quiet)
+            # `bun pm pack --quiet` prints the tarball filename, but bun 1.3.5
+            # wraps it in stray whitespace — a leading \n on Linux runners
+            # produces an unsplit `\n<filename>\n` blob that command
+            # substitution turns into a path with a literal newline in the
+            # middle, which `npm publish` then can't open (ENOENT).
+            # `tr -d '[:space:]'` strips all whitespace defensively so the
+            # variable holds only the filename, regardless of bun version.
+            # The tarball is written to the package dir.
+            tarball=$(cd "$pkg_dir" && bun pm pack --quiet | tr -d '[:space:]')
             tarball_abs="$(cd "$pkg_dir" && readlink -f "$tarball")"
+            if [ ! -f "$tarball_abs" ]; then
+              echo "::error::bun pm pack produced no tarball at expected path: $tarball_abs"
+              exit 1
+            fi
             echo "  tarball: $tarball_abs"
             echo "::endgroup::"
             echo "::group::Publishing $pkg_name@$pkg_version (with provenance)"


### PR DESCRIPTION
## Summary

The v0.5.2 publish job [failed with ENOENT](https://github.com/dodopayments/dualmark/actions/runs/25732533886) on the first package (`@dualmark/astro`):

```
tarball: /home/runner/work/dualmark/dualmark/packages/astro/
dualmark-astro-0.5.2.tgz   ← path is split across two lines
npm warn tarball ... seems to be corrupted. Trying again.
npm error code ENOENT
```

## Root cause

`bun pm pack --quiet` on Linux runners (bun 1.3.5) emits the tarball filename wrapped in stray whitespace — `\n<filename>\n`. Reproduced locally:

```
$ bun pm pack --quiet | od -c | head -3
0000000   \n   d   u   a   l   m   a   r   k   -   c   o   r   e   -   0
0000020   .   5   .   2   .   t   g   z   \n
```

The leading `\n` survived `$( ... )` command substitution (only **trailing** newlines are stripped by POSIX), so the variable held `\n<filename>` — `readlink -f` then produced an absolute path with a literal newline in it, which `npm publish` correctly refused to open.

## Fix

```diff
- tarball=$(cd "$pkg_dir" && bun pm pack --quiet)
+ tarball=$(cd "$pkg_dir" && bun pm pack --quiet | tr -d '[:space:]')
  tarball_abs="$(cd "$pkg_dir" && readlink -f "$tarball")"
+ if [ ! -f "$tarball_abs" ]; then
+   echo "::error::bun pm pack produced no tarball at expected path: $tarball_abs"
+   exit 1
+ fi
```

`tr -d '[:space:]'` strips any whitespace around the filename — defensive against current and any future bun stdout formatting changes. The follow-up `-f` guard makes any future regression of this same shape fail fast with a clear error, instead of leaking confusing ENOENT spew from npm.

## Validation

- Local repro of the bug + verified fix on `@dualmark/core` and `@dualmark/astro`
- `actionlint .github/workflows/release.yml` passes
- No packages were published in the failed run (verified `npm view @dualmark/*@0.5.2` → 404), so the idempotent skip check in the publish loop will correctly handle the re-run

## How to land + recover

1. Merge this PR
2. Trigger the publish via **Actions → Release (npm publish) → Run workflow → tag: `v0.5.2`**
3. Verify the Provenance badge appears on each `@dualmark/*` package page on npmjs.com
4. Run `npm view @dualmark/core@0.5.2 --json | jq .dist.attestations` to confirm the Sigstore attestation is present