### PR TITLE
feat(converters): add status page converter (closes #12)

### DIFF
--- a/.changeset/goofy-bushes-begin.md
+++ b/.changeset/goofy-bushes-begin.md
@@ -1,5 +1,5 @@
 ---
-"@dualmark/converters": major
+"@dualmark/converters": minor
 ---
 
 Add status page converter for uptime/status pages

--- a/.changeset/goofy-bushes-begin.md
+++ b/.changeset/goofy-bushes-begin.md
@@ -1,0 +1,5 @@
+---
+"@dualmark/converters": major
+---
+
+Add status page converter for uptime/status pages

--- a/README.md
+++ b/README.md
@@ -261,10 +261,10 @@ Plus:
 | Surface | Status |
 |---|---|
 | `@dualmark/core` | 174 tests pass (vitest + fast-check property tests) |
-| `@dualmark/converters` | 28 tests pass |
+| `@dualmark/converters` | 31 tests pass |
 | `@dualmark/cloudflare` | 23 tests pass |
 | `@dualmark/cli` | 17 tests pass |
-| `@dualmark/astro` | 35 tests pass |
+| `@dualmark/astro` | 36 tests pass |
 | `@dualmark/nextjs` | 47 tests pass |
 | `examples/astro-blog` | **80/80** under `astro dev` (`--skip-negotiation`) |
 | `examples/astro-cloudflare-full` | **125/125 perfect** under `wrangler dev` (full negotiation) |
@@ -274,7 +274,7 @@ Plus:
 
 ```bash
 bun install
-bun run build && bun run test && bun run typecheck   # 324 tests across 6 packages
+bun run build && bun run test && bun run typecheck   # 328 tests across 6 packages
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ export default defineConfig({
     dualmark({
       siteUrl: "https://yourcompany.com",
       collections: {
-        blog: { converter: "blog" }, // /blog/*.md auto-generated
-        glossary: { converter: "glossary" }, // /glossary/*.md auto-generated
+        blog: { converter: "blog" },           // /blog/*.md auto-generated
+        glossary: { converter: "glossary" },   // /glossary/*.md auto-generated
       },
-      llmsTxt: { enabled: true }, // /llms.txt auto-generated
+      llmsTxt: { enabled: true },              // /llms.txt auto-generated
     }),
   ],
 });
@@ -133,14 +133,14 @@ export default createAEOWorker({
 
 You already invested in SEO. Now invest in AEO — for **a fraction of the effort**.
 
-| Problem                                   | Without Dualmark                                                          | With Dualmark                                                                                         |
-| ----------------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| **AI cites competitors instead of you**   | Bots scrape your HTML, get nav menus + JS errors, pick the cleaner source | Same URL serves clean markdown to bots, polished HTML to humans                                       |
-| **No way to know if you're discoverable** | "We hope ChatGPT can read this"                                           | `dualmark verify` returns a 0–125 score with line-item failures                                       |
-| **`llms.txt` proposal keeps changing**    | Hand-maintained, drifts from sitemap                                      | Auto-generated from the same config that drives your routes                                           |
-| **Every team rebuilds this**              | Custom middleware in every repo, none of them quite right                 | One battle-tested package, conforms to a public spec                                                  |
-| **No analytics for AI traffic**           | "Was that a bot or a human?"                                              | `onAIRequest` hook + Cloudflare Analytics Engine integration: bot name, vendor, page, tokens, country |
-| **Slow to roll out across pages**         | Marketing waits weeks for engineering                                     | Add `converter: "compare"` to a collection — done. 14 converters bundled.                             |
+| Problem | Without Dualmark | With Dualmark |
+|---|---|---|
+| **AI cites competitors instead of you** | Bots scrape your HTML, get nav menus + JS errors, pick the cleaner source | Same URL serves clean markdown to bots, polished HTML to humans |
+| **No way to know if you're discoverable** | "We hope ChatGPT can read this" | `dualmark verify` returns a 0–125 score with line-item failures |
+| **`llms.txt` proposal keeps changing** | Hand-maintained, drifts from sitemap | Auto-generated from the same config that drives your routes |
+| **Every team rebuilds this** | Custom middleware in every repo, none of them quite right | One battle-tested package, conforms to a public spec |
+| **No analytics for AI traffic** | "Was that a bot or a human?" | `onAIRequest` hook + Cloudflare Analytics Engine integration: bot name, vendor, page, tokens, country |
+| **Slow to roll out across pages** | Marketing waits weeks for engineering | Add `converter: "compare"` to a collection — done. Production-tested converters bundled. |
 
 **Built and battle-tested at [Dodo Payments](https://dodopayments.com)** for our own marketing site. Now extracted as OSS so you don't have to write the same content negotiation, bot detection, and edge wrapping over and over.
 
@@ -155,7 +155,6 @@ yourcompany.com/llms.txt            ← AI agents discover everything
 ```
 
 Same URL. Same content. Different rendering. Picked automatically by:
-
 - `Accept: text/markdown` header → markdown
 - Known AI bot User-Agent (GPTBot, ClaudeBot, PerplexityBot, +21 more) → markdown
 - Direct `.md` URL → markdown
@@ -167,24 +166,24 @@ No duplicate content penalties (markdown twin sets `X-Robots-Tag: noindex`). No 
 
 ## Built-in converters (`@dualmark/converters`)
 
-Drop-in markdown generation for the 14 page types every marketing site has:
+Drop-in markdown generation for the page types every marketing site has:
 
-| Converter     | What it's for                  | Marketing examples                                       |
-| ------------- | ------------------------------ | -------------------------------------------------------- |
-| `blog`        | Long-form posts                | Engineering blog, customer stories                       |
-| `case-study`  | Customer wins                  | Logos with stats and pull-quote                          |
-| `changelog`   | Release notes                  | "What's new in v1.4" with grouped changes                |
-| `compare`     | Us vs. competitor              | "Stripe alternative" pages                               |
-| `docs`        | Documentation                  | Getting started, API guides                              |
-| `feature`     | Product/feature pages          | "Webhooks", "SSO" — problem/solution + FAQ               |
-| `glossary`    | Term definitions               | "What is a payment gateway?"                             |
-| `integration` | App marketplace / integrations | "Connect Stripe to Acme", Slack connector pages          |
-| `legal`       | Policy pages                   | Terms, Privacy, DPA                                      |
-| `pricing`     | Pricing tables                 | Tier comparison with CTAs                                |
-| `pseo`        | Programmatic SEO               | "SEO services in San Francisco" with facts + cross-links |
-| `status-page` | Uptime / status                | Public component health + incidents                      |
-| `tool`        | Standalone calculators         | "Currency converter"                                     |
-| `video`       | Video landing pages            | Webinar replays                                          |
+| Converter | What it's for | Marketing examples |
+|---|---|---|
+| `blog` | Long-form posts | Engineering blog, customer stories |
+| `case-study` | Customer wins | Logos with stats and pull-quote |
+| `changelog` | Release notes | "What's new in v1.4" with grouped changes |
+| `compare` | Us vs. competitor | "Stripe alternative" pages |
+| `docs` | Documentation | Getting started, API guides |
+| `feature` | Product/feature pages | "Webhooks", "SSO" — problem/solution + FAQ |
+| `glossary` | Term definitions | "What is a payment gateway?" |
+| `integration` | App marketplace / integrations | "Connect Stripe to Acme", Slack connector pages |
+| `legal` | Policy pages | Terms, Privacy, DPA |
+| `pricing` | Pricing tables | Tier comparison with CTAs |
+| `pseo` | Programmatic SEO | "SEO services in San Francisco" with facts + cross-links |
+| `status-page` | Uptime / status | Public component health + incidents |
+| `tool` | Standalone calculators | "Currency converter" |
+| `video` | Video landing pages | Webinar replays |
 
 Each converter takes your collection entry → returns clean markdown with the right structure for AI consumption (title, description, breadcrumbs, FAQ extraction, related links). No prompt engineering required.
 
@@ -196,7 +195,7 @@ const convert = compareConverter({
   basePath: "/compare",
 });
 
-const md = convert(yourComparePage); // → battle-tested markdown layout
+const md = convert(yourComparePage);  // → battle-tested markdown layout
 ```
 
 ---
@@ -239,14 +238,14 @@ Three conformance levels — **Basic** (60%), **Standard** (80%), **Advanced** (
 
 ## What's in the box
 
-| Package                                         | npm                          | Size  | What it does                                                                                                                                                                                                |
-| ----------------------------------------------- | ---------------------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`@dualmark/core`](./packages/core)             | `npm i @dualmark/core`       | 14 KB | Framework-agnostic primitives: content negotiation (RFC 7231), AI-bot detection (24 known bots), markdown response builder, token estimation, composition helpers, `llms.txt` rendering. Zero runtime deps. |
-| [`@dualmark/converters`](./packages/converters) | `npm i @dualmark/converters` | 16 KB | 14 production-tested converter factories.                                                                                                                                                                   |
-| [`@dualmark/astro`](./packages/astro)           | `npm i @dualmark/astro`      | 22 KB | Astro 5 integration. Auto-generates `.md` endpoints, ships middleware, generates `llms.txt`.                                                                                                                |
-| [`@dualmark/nextjs`](./packages/nextjs)         | `npm i @dualmark/nextjs`     | 15 KB | Next.js App Router adapter. `withDualmark()`, `createDualmarkMiddleware()`, `createDualmarkRouteHandler()`, `createLlmsTxtHandler()`.                                                                       |
-| [`@dualmark/cloudflare`](./packages/cloudflare) | `npm i @dualmark/cloudflare` | 9 KB  | Workers edge adapter. Wraps any upstream Worker. Hooks for analytics + telemetry.                                                                                                                           |
-| [`@dualmark/cli`](./packages/cli)               | `npm i -g @dualmark/cli`     | 16 KB | `dualmark verify <url>`. Programmatic API too.                                                                                                                                                              |
+| Package | npm | Size | What it does |
+|---|---|---|---|
+| [`@dualmark/core`](./packages/core) | `npm i @dualmark/core` | 14 KB | Framework-agnostic primitives: content negotiation (RFC 7231), AI-bot detection (24 known bots), markdown response builder, token estimation, composition helpers, `llms.txt` rendering. Zero runtime deps. |
+| [`@dualmark/converters`](./packages/converters) | `npm i @dualmark/converters` | 16 KB | Production-tested converter factories. |
+| [`@dualmark/astro`](./packages/astro) | `npm i @dualmark/astro` | 22 KB | Astro 5 integration. Auto-generates `.md` endpoints, ships middleware, generates `llms.txt`. |
+| [`@dualmark/nextjs`](./packages/nextjs) | `npm i @dualmark/nextjs` | 15 KB | Next.js App Router adapter. `withDualmark()`, `createDualmarkMiddleware()`, `createDualmarkRouteHandler()`, `createLlmsTxtHandler()`. |
+| [`@dualmark/cloudflare`](./packages/cloudflare) | `npm i @dualmark/cloudflare` | 9 KB | Workers edge adapter. Wraps any upstream Worker. Hooks for analytics + telemetry. |
+| [`@dualmark/cli`](./packages/cli) | `npm i -g @dualmark/cli` | 16 KB | `dualmark verify <url>`. Programmatic API too. |
 
 Plus:
 
@@ -259,19 +258,19 @@ Plus:
 
 ## End-to-end verified
 
-| Surface                          | Status                                                      |
-| -------------------------------- | ----------------------------------------------------------- |
-| `@dualmark/core`                 | 174 tests pass (vitest + fast-check property tests)         |
-| `@dualmark/converters`           | 28 tests pass                                               |
-| `@dualmark/cloudflare`           | 23 tests pass                                               |
-| `@dualmark/cli`                  | 17 tests pass                                               |
-| `@dualmark/astro`                | 36 tests pass                                               |
-| `@dualmark/nextjs`               | 47 tests pass                                               |
-| `examples/astro-blog`            | **80/80** under `astro dev` (`--skip-negotiation`)          |
+| Surface | Status |
+|---|---|
+| `@dualmark/core` | 174 tests pass (vitest + fast-check property tests) |
+| `@dualmark/converters` | 28 tests pass |
+| `@dualmark/cloudflare` | 23 tests pass |
+| `@dualmark/cli` | 17 tests pass |
+| `@dualmark/astro` | 35 tests pass |
+| `@dualmark/nextjs` | 47 tests pass |
+| `examples/astro-blog` | **80/80** under `astro dev` (`--skip-negotiation`) |
 | `examples/astro-cloudflare-full` | **125/125 perfect** under `wrangler dev` (full negotiation) |
-| `examples/nextjs-app-router`     | **120/125** under `next dev` (now using `@dualmark/nextjs`) |
-| `apps/docs`                      | 26 routes prerendered, all serve 200                        |
-| `/play` route                    | Live at dualmark.dev/play, integrated into the docs app     |
+| `examples/nextjs-app-router` | **120/125** under `next dev` (now using `@dualmark/nextjs`) |
+| `apps/docs` | 26 routes prerendered, all serve 200 |
+| `/play` route | Live at dualmark.dev/play, integrated into the docs app |
 
 ```bash
 bun install

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ export default defineConfig({
     dualmark({
       siteUrl: "https://yourcompany.com",
       collections: {
-        blog: { converter: "blog" },           // /blog/*.md auto-generated
-        glossary: { converter: "glossary" },   // /glossary/*.md auto-generated
+        blog: { converter: "blog" }, // /blog/*.md auto-generated
+        glossary: { converter: "glossary" }, // /glossary/*.md auto-generated
       },
-      llmsTxt: { enabled: true },              // /llms.txt auto-generated
+      llmsTxt: { enabled: true }, // /llms.txt auto-generated
     }),
   ],
 });
@@ -133,14 +133,14 @@ export default createAEOWorker({
 
 You already invested in SEO. Now invest in AEO — for **a fraction of the effort**.
 
-| Problem | Without Dualmark | With Dualmark |
-|---|---|---|
-| **AI cites competitors instead of you** | Bots scrape your HTML, get nav menus + JS errors, pick the cleaner source | Same URL serves clean markdown to bots, polished HTML to humans |
-| **No way to know if you're discoverable** | "We hope ChatGPT can read this" | `dualmark verify` returns a 0–125 score with line-item failures |
-| **`llms.txt` proposal keeps changing** | Hand-maintained, drifts from sitemap | Auto-generated from the same config that drives your routes |
-| **Every team rebuilds this** | Custom middleware in every repo, none of them quite right | One battle-tested package, conforms to a public spec |
-| **No analytics for AI traffic** | "Was that a bot or a human?" | `onAIRequest` hook + Cloudflare Analytics Engine integration: bot name, vendor, page, tokens, country |
-| **Slow to roll out across pages** | Marketing waits weeks for engineering | Add `converter: "compare"` to a collection — done. 13 converters bundled. |
+| Problem                                   | Without Dualmark                                                          | With Dualmark                                                                                         |
+| ----------------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| **AI cites competitors instead of you**   | Bots scrape your HTML, get nav menus + JS errors, pick the cleaner source | Same URL serves clean markdown to bots, polished HTML to humans                                       |
+| **No way to know if you're discoverable** | "We hope ChatGPT can read this"                                           | `dualmark verify` returns a 0–125 score with line-item failures                                       |
+| **`llms.txt` proposal keeps changing**    | Hand-maintained, drifts from sitemap                                      | Auto-generated from the same config that drives your routes                                           |
+| **Every team rebuilds this**              | Custom middleware in every repo, none of them quite right                 | One battle-tested package, conforms to a public spec                                                  |
+| **No analytics for AI traffic**           | "Was that a bot or a human?"                                              | `onAIRequest` hook + Cloudflare Analytics Engine integration: bot name, vendor, page, tokens, country |
+| **Slow to roll out across pages**         | Marketing waits weeks for engineering                                     | Add `converter: "compare"` to a collection — done. 14 converters bundled.                             |
 
 **Built and battle-tested at [Dodo Payments](https://dodopayments.com)** for our own marketing site. Now extracted as OSS so you don't have to write the same content negotiation, bot detection, and edge wrapping over and over.
 
@@ -155,6 +155,7 @@ yourcompany.com/llms.txt            ← AI agents discover everything
 ```
 
 Same URL. Same content. Different rendering. Picked automatically by:
+
 - `Accept: text/markdown` header → markdown
 - Known AI bot User-Agent (GPTBot, ClaudeBot, PerplexityBot, +21 more) → markdown
 - Direct `.md` URL → markdown
@@ -166,23 +167,24 @@ No duplicate content penalties (markdown twin sets `X-Robots-Tag: noindex`). No 
 
 ## Built-in converters (`@dualmark/converters`)
 
-Drop-in markdown generation for the 13 page types every marketing site has:
+Drop-in markdown generation for the 14 page types every marketing site has:
 
-| Converter | What it's for | Marketing examples |
-|---|---|---|
-| `blog` | Long-form posts | Engineering blog, customer stories |
-| `case-study` | Customer wins | Logos with stats and pull-quote |
-| `changelog` | Release notes | "What's new in v1.4" with grouped changes |
-| `compare` | Us vs. competitor | "Stripe alternative" pages |
-| `docs` | Documentation | Getting started, API guides |
-| `feature` | Product/feature pages | "Webhooks", "SSO" — problem/solution + FAQ |
-| `glossary` | Term definitions | "What is a payment gateway?" |
-| `integration` | App marketplace / integrations | "Connect Stripe to Acme", Slack connector pages |
-| `legal` | Policy pages | Terms, Privacy, DPA |
-| `pricing` | Pricing tables | Tier comparison with CTAs |
-| `pseo` | Programmatic SEO | "SEO services in San Francisco" with facts + cross-links |
-| `tool` | Standalone calculators | "Currency converter" |
-| `video` | Video landing pages | Webinar replays |
+| Converter     | What it's for                  | Marketing examples                                       |
+| ------------- | ------------------------------ | -------------------------------------------------------- |
+| `blog`        | Long-form posts                | Engineering blog, customer stories                       |
+| `case-study`  | Customer wins                  | Logos with stats and pull-quote                          |
+| `changelog`   | Release notes                  | "What's new in v1.4" with grouped changes                |
+| `compare`     | Us vs. competitor              | "Stripe alternative" pages                               |
+| `docs`        | Documentation                  | Getting started, API guides                              |
+| `feature`     | Product/feature pages          | "Webhooks", "SSO" — problem/solution + FAQ               |
+| `glossary`    | Term definitions               | "What is a payment gateway?"                             |
+| `integration` | App marketplace / integrations | "Connect Stripe to Acme", Slack connector pages          |
+| `legal`       | Policy pages                   | Terms, Privacy, DPA                                      |
+| `pricing`     | Pricing tables                 | Tier comparison with CTAs                                |
+| `pseo`        | Programmatic SEO               | "SEO services in San Francisco" with facts + cross-links |
+| `status-page` | Uptime / status                | Public component health + incidents                      |
+| `tool`        | Standalone calculators         | "Currency converter"                                     |
+| `video`       | Video landing pages            | Webinar replays                                          |
 
 Each converter takes your collection entry → returns clean markdown with the right structure for AI consumption (title, description, breadcrumbs, FAQ extraction, related links). No prompt engineering required.
 
@@ -194,7 +196,7 @@ const convert = compareConverter({
   basePath: "/compare",
 });
 
-const md = convert(yourComparePage);  // → battle-tested markdown layout
+const md = convert(yourComparePage); // → battle-tested markdown layout
 ```
 
 ---
@@ -237,14 +239,14 @@ Three conformance levels — **Basic** (60%), **Standard** (80%), **Advanced** (
 
 ## What's in the box
 
-| Package | npm | Size | What it does |
-|---|---|---|---|
-| [`@dualmark/core`](./packages/core) | `npm i @dualmark/core` | 14 KB | Framework-agnostic primitives: content negotiation (RFC 7231), AI-bot detection (24 known bots), markdown response builder, token estimation, composition helpers, `llms.txt` rendering. Zero runtime deps. |
-| [`@dualmark/converters`](./packages/converters) | `npm i @dualmark/converters` | 16 KB | 13 production-tested converter factories. |
-| [`@dualmark/astro`](./packages/astro) | `npm i @dualmark/astro` | 22 KB | Astro 5 integration. Auto-generates `.md` endpoints, ships middleware, generates `llms.txt`. |
-| [`@dualmark/nextjs`](./packages/nextjs) | `npm i @dualmark/nextjs` | 15 KB | Next.js App Router adapter. `withDualmark()`, `createDualmarkMiddleware()`, `createDualmarkRouteHandler()`, `createLlmsTxtHandler()`. |
-| [`@dualmark/cloudflare`](./packages/cloudflare) | `npm i @dualmark/cloudflare` | 9 KB | Workers edge adapter. Wraps any upstream Worker. Hooks for analytics + telemetry. |
-| [`@dualmark/cli`](./packages/cli) | `npm i -g @dualmark/cli` | 16 KB | `dualmark verify <url>`. Programmatic API too. |
+| Package                                         | npm                          | Size  | What it does                                                                                                                                                                                                |
+| ----------------------------------------------- | ---------------------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`@dualmark/core`](./packages/core)             | `npm i @dualmark/core`       | 14 KB | Framework-agnostic primitives: content negotiation (RFC 7231), AI-bot detection (24 known bots), markdown response builder, token estimation, composition helpers, `llms.txt` rendering. Zero runtime deps. |
+| [`@dualmark/converters`](./packages/converters) | `npm i @dualmark/converters` | 16 KB | 14 production-tested converter factories.                                                                                                                                                                   |
+| [`@dualmark/astro`](./packages/astro)           | `npm i @dualmark/astro`      | 22 KB | Astro 5 integration. Auto-generates `.md` endpoints, ships middleware, generates `llms.txt`.                                                                                                                |
+| [`@dualmark/nextjs`](./packages/nextjs)         | `npm i @dualmark/nextjs`     | 15 KB | Next.js App Router adapter. `withDualmark()`, `createDualmarkMiddleware()`, `createDualmarkRouteHandler()`, `createLlmsTxtHandler()`.                                                                       |
+| [`@dualmark/cloudflare`](./packages/cloudflare) | `npm i @dualmark/cloudflare` | 9 KB  | Workers edge adapter. Wraps any upstream Worker. Hooks for analytics + telemetry.                                                                                                                           |
+| [`@dualmark/cli`](./packages/cli)               | `npm i -g @dualmark/cli`     | 16 KB | `dualmark verify <url>`. Programmatic API too.                                                                                                                                                              |
 
 Plus:
 
@@ -257,19 +259,19 @@ Plus:
 
 ## End-to-end verified
 
-| Surface | Status |
-|---|---|
-| `@dualmark/core` | 174 tests pass (vitest + fast-check property tests) |
-| `@dualmark/converters` | 28 tests pass |
-| `@dualmark/cloudflare` | 23 tests pass |
-| `@dualmark/cli` | 17 tests pass |
-| `@dualmark/astro` | 35 tests pass |
-| `@dualmark/nextjs` | 47 tests pass |
-| `examples/astro-blog` | **80/80** under `astro dev` (`--skip-negotiation`) |
+| Surface                          | Status                                                      |
+| -------------------------------- | ----------------------------------------------------------- |
+| `@dualmark/core`                 | 174 tests pass (vitest + fast-check property tests)         |
+| `@dualmark/converters`           | 28 tests pass                                               |
+| `@dualmark/cloudflare`           | 23 tests pass                                               |
+| `@dualmark/cli`                  | 17 tests pass                                               |
+| `@dualmark/astro`                | 36 tests pass                                               |
+| `@dualmark/nextjs`               | 47 tests pass                                               |
+| `examples/astro-blog`            | **80/80** under `astro dev` (`--skip-negotiation`)          |
 | `examples/astro-cloudflare-full` | **125/125 perfect** under `wrangler dev` (full negotiation) |
-| `examples/nextjs-app-router` | **120/125** under `next dev` (now using `@dualmark/nextjs`) |
-| `apps/docs` | 26 routes prerendered, all serve 200 |
-| `/play` route | Live at dualmark.dev/play, integrated into the docs app |
+| `examples/nextjs-app-router`     | **120/125** under `next dev` (now using `@dualmark/nextjs`) |
+| `apps/docs`                      | 26 routes prerendered, all serve 200                        |
+| `/play` route                    | Live at dualmark.dev/play, integrated into the docs app     |
 
 ```bash
 bun install

--- a/apps/docs/app/raw/index.md/route.ts
+++ b/apps/docs/app/raw/index.md/route.ts
@@ -24,7 +24,7 @@ See https://dualmark.dev/docs/quickstart for the full integration guide.
 - \`@dualmark/astro\` — Astro 5 integration
 - \`@dualmark/cloudflare\` — Workers edge adapter
 - \`@dualmark/cli\` — \`dualmark verify\` conformance test runner
-- \`@dualmark/converters\` — 13 production-tested page-type converters
+- \`@dualmark/converters\` — 14 production-tested page-type converters
 
 ## Links
 

--- a/apps/docs/app/raw/index.md/route.ts
+++ b/apps/docs/app/raw/index.md/route.ts
@@ -24,7 +24,7 @@ See https://dualmark.dev/docs/quickstart for the full integration guide.
 - \`@dualmark/astro\` — Astro 5 integration
 - \`@dualmark/cloudflare\` — Workers edge adapter
 - \`@dualmark/cli\` — \`dualmark verify\` conformance test runner
-- \`@dualmark/converters\` — 14 production-tested page-type converters
+- \`@dualmark/converters\` — production-tested page-type converters
 
 ## Links
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -57,7 +57,7 @@ Built and battle-tested at [Dodo Payments](https://dodopayments.com).
 
 <Cards>
   <Card icon={<Box />} title="@dualmark/core" href="/docs/packages/core" description="Framework-agnostic primitives — content negotiation, AI-bot detection, markdown responses." />
-  <Card icon={<ArrowLeftRight />} title="@dualmark/converters" href="/docs/packages/converters" description="14 production-tested page-type converters — blog, glossary, integration, pricing, status pages, changelog, and more." />
+  <Card icon={<ArrowLeftRight />} title="@dualmark/converters" href="/docs/packages/converters" description="Production-tested page-type converters — blog, glossary, integration, pricing, changelog, and more." />
   <Card icon={<AstroLogo />} title="@dualmark/astro" href="/docs/packages/astro" description="Astro 5 integration with auto-generated routes and llms.txt." />
   <Card icon={<NextLogo />} title="@dualmark/nextjs" href="/docs/packages/nextjs" description="Next.js 15 App Router adapter — withDualmark, middleware factory, route handler factory." />
   <Card icon={<CloudflareLogo />} title="@dualmark/cloudflare" href="/docs/packages/cloudflare" description="Workers edge adapter with hooks for analytics and transformations." />

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -57,7 +57,7 @@ Built and battle-tested at [Dodo Payments](https://dodopayments.com).
 
 <Cards>
   <Card icon={<Box />} title="@dualmark/core" href="/docs/packages/core" description="Framework-agnostic primitives — content negotiation, AI-bot detection, markdown responses." />
-  <Card icon={<ArrowLeftRight />} title="@dualmark/converters" href="/docs/packages/converters" description="13 production-tested page-type converters — blog, glossary, integration, pricing, changelog, and more." />
+  <Card icon={<ArrowLeftRight />} title="@dualmark/converters" href="/docs/packages/converters" description="14 production-tested page-type converters — blog, glossary, integration, pricing, status pages, changelog, and more." />
   <Card icon={<AstroLogo />} title="@dualmark/astro" href="/docs/packages/astro" description="Astro 5 integration with auto-generated routes and llms.txt." />
   <Card icon={<NextLogo />} title="@dualmark/nextjs" href="/docs/packages/nextjs" description="Next.js 15 App Router adapter — withDualmark, middleware factory, route handler factory." />
   <Card icon={<CloudflareLogo />} title="@dualmark/cloudflare" href="/docs/packages/cloudflare" description="Workers edge adapter with hooks for analytics and transformations." />

--- a/apps/docs/content/docs/integrations/astro.mdx
+++ b/apps/docs/content/docs/integrations/astro.mdx
@@ -6,9 +6,21 @@ description: Add Dualmark to an Astro 5 site with one integration.
 ## Install
 
 <Tabs items={["bun", "npm", "yarn"]}>
-  <Tab value="bun">```bash bun add @dualmark/astro @dualmark/core @dualmark/converters ```</Tab>
-  <Tab value="npm">```bash npm install @dualmark/astro @dualmark/core @dualmark/converters ```</Tab>
-  <Tab value="yarn">```bash yarn add @dualmark/astro @dualmark/core @dualmark/converters ```</Tab>
+<Tab value="bun">
+```bash
+bun add @dualmark/astro @dualmark/core @dualmark/converters
+```
+</Tab>
+<Tab value="npm">
+```bash
+npm install @dualmark/astro @dualmark/core @dualmark/converters
+```
+</Tab>
+<Tab value="yarn">
+```bash
+yarn add @dualmark/astro @dualmark/core @dualmark/converters
+```
+</Tab>
 </Tabs>
 
 ## Minimal config

--- a/apps/docs/content/docs/integrations/astro.mdx
+++ b/apps/docs/content/docs/integrations/astro.mdx
@@ -6,21 +6,9 @@ description: Add Dualmark to an Astro 5 site with one integration.
 ## Install
 
 <Tabs items={["bun", "npm", "yarn"]}>
-<Tab value="bun">
-```bash
-bun add @dualmark/astro @dualmark/core @dualmark/converters
-```
-</Tab>
-<Tab value="npm">
-```bash
-npm install @dualmark/astro @dualmark/core @dualmark/converters
-```
-</Tab>
-<Tab value="yarn">
-```bash
-yarn add @dualmark/astro @dualmark/core @dualmark/converters
-```
-</Tab>
+  <Tab value="bun">```bash bun add @dualmark/astro @dualmark/core @dualmark/converters ```</Tab>
+  <Tab value="npm">```bash npm install @dualmark/astro @dualmark/core @dualmark/converters ```</Tab>
+  <Tab value="yarn">```bash yarn add @dualmark/astro @dualmark/core @dualmark/converters ```</Tab>
 </Tabs>
 
 ## Minimal config
@@ -108,7 +96,7 @@ dualmark({
 
 ## Available converters
 
-`converter: "blog" | "case-study" | "changelog" | "compare" | "docs" | "feature" | "glossary" | "integration" | "legal" | "pricing" | "pseo" | "tool" | "video"` — see [@dualmark/converters](/docs/packages/converters).
+`converter: "blog" | "case-study" | "changelog" | "compare" | "docs" | "feature" | "glossary" | "integration" | "legal" | "pricing" | "pseo" | "status-page" | "tool" | "video"` — see [@dualmark/converters](/docs/packages/converters).
 
 You can also pass a custom function: `converter: (entry) => string`.
 

--- a/apps/docs/content/docs/integrations/nextjs.mdx
+++ b/apps/docs/content/docs/integrations/nextjs.mdx
@@ -38,11 +38,21 @@ app/
 ## Install
 
 <Tabs items={["bun", "npm", "yarn"]}>
-  <Tab value="bun">```bash bun add @dualmark/nextjs @dualmark/core @dualmark/converters ```</Tab>
-  <Tab value="npm">
-    ```bash npm install @dualmark/nextjs @dualmark/core @dualmark/converters ```
-  </Tab>
-  <Tab value="yarn">```bash yarn add @dualmark/nextjs @dualmark/core @dualmark/converters ```</Tab>
+<Tab value="bun">
+```bash
+bun add @dualmark/nextjs @dualmark/core @dualmark/converters
+```
+</Tab>
+<Tab value="npm">
+```bash
+npm install @dualmark/nextjs @dualmark/core @dualmark/converters
+```
+</Tab>
+<Tab value="yarn">
+```bash
+yarn add @dualmark/nextjs @dualmark/core @dualmark/converters
+```
+</Tab>
 </Tabs>
 
 ## next.config.mjs
@@ -84,8 +94,7 @@ export const config = {
 _On Next.js ≤15, name the file `middleware.ts` instead. Body is identical._
 
 <Callout>
-  The `matcher` source must be an inline literal — Next.js parses `export const config` statically
-  and rejects imports/expressions. If you customize `internalNamespace`, replace `md/` accordingly.
+  The `matcher` source must be an inline literal — Next.js parses `export const config` statically and rejects imports/expressions. If you customize `internalNamespace`, replace `md/` accordingly.
 </Callout>
 
 ## app/md/[...path]/route.ts
@@ -165,12 +174,12 @@ Expect **120/125** under `next dev` (full Standard conformance).
 
 If you wired `@dualmark/core` into Next.js by hand before `@dualmark/nextjs` shipped, the migration is mechanical:
 
-| Before (`@dualmark/core` only)                                                                       | After (`@dualmark/nextjs`)                                                               |
-| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| Hand-rolled `proxy.ts`/`middleware.ts` with `detectAIBot` + `negotiateFormat` + manual rewrite logic | `createDualmarkMiddleware({ siteUrl })`                                                  |
-| Hand-rolled `app/md/[...path]/route.ts` with `if`-chains over the joined path                        | `createDualmarkRouteHandler({ siteUrl, collections, staticPages, parameterizedRoutes })` |
-| Hand-rolled `app/llms.txt/route.ts` calling `renderLlmsTxt`                                          | `createLlmsTxtHandler({ brandName, sections })`                                          |
-| Manual `transpilePackages: ["@dualmark/core", ...]`                                                  | `withDualmark(nextConfig, options)`                                                      |
+| Before (`@dualmark/core` only) | After (`@dualmark/nextjs`) |
+|---|---|
+| Hand-rolled `proxy.ts`/`middleware.ts` with `detectAIBot` + `negotiateFormat` + manual rewrite logic | `createDualmarkMiddleware({ siteUrl })` |
+| Hand-rolled `app/md/[...path]/route.ts` with `if`-chains over the joined path | `createDualmarkRouteHandler({ siteUrl, collections, staticPages, parameterizedRoutes })` |
+| Hand-rolled `app/llms.txt/route.ts` calling `renderLlmsTxt` | `createLlmsTxtHandler({ brandName, sections })` |
+| Manual `transpilePackages: ["@dualmark/core", ...]` | `withDualmark(nextConfig, options)` |
 
 The internal namespace, response headers, and conformance score are unchanged. The reference example (`examples/nextjs-app-router`) is the canonical migration — it went from ~120 lines hand-rolled to ~50 lines with the adapter, same 120/125 score.
 

--- a/apps/docs/content/docs/integrations/nextjs.mdx
+++ b/apps/docs/content/docs/integrations/nextjs.mdx
@@ -38,21 +38,11 @@ app/
 ## Install
 
 <Tabs items={["bun", "npm", "yarn"]}>
-<Tab value="bun">
-```bash
-bun add @dualmark/nextjs @dualmark/core @dualmark/converters
-```
-</Tab>
-<Tab value="npm">
-```bash
-npm install @dualmark/nextjs @dualmark/core @dualmark/converters
-```
-</Tab>
-<Tab value="yarn">
-```bash
-yarn add @dualmark/nextjs @dualmark/core @dualmark/converters
-```
-</Tab>
+  <Tab value="bun">```bash bun add @dualmark/nextjs @dualmark/core @dualmark/converters ```</Tab>
+  <Tab value="npm">
+    ```bash npm install @dualmark/nextjs @dualmark/core @dualmark/converters ```
+  </Tab>
+  <Tab value="yarn">```bash yarn add @dualmark/nextjs @dualmark/core @dualmark/converters ```</Tab>
 </Tabs>
 
 ## next.config.mjs
@@ -94,7 +84,8 @@ export const config = {
 _On Next.js ≤15, name the file `middleware.ts` instead. Body is identical._
 
 <Callout>
-  The `matcher` source must be an inline literal — Next.js parses `export const config` statically and rejects imports/expressions. If you customize `internalNamespace`, replace `md/` accordingly.
+  The `matcher` source must be an inline literal — Next.js parses `export const config` statically
+  and rejects imports/expressions. If you customize `internalNamespace`, replace `md/` accordingly.
 </Callout>
 
 ## app/md/[...path]/route.ts
@@ -158,7 +149,7 @@ export const GET = handler.GET;
 
 ## Built-in converter names
 
-`blog`, `case-study`, `changelog`, `compare`, `docs`, `feature`, `glossary`, `integration`, `legal`, `pricing`, `pseo`, `tool`, `video` — see [@dualmark/converters](/docs/packages/converters). Or pass a custom function `(entry) => string`.
+`blog`, `case-study`, `changelog`, `compare`, `docs`, `feature`, `glossary`, `integration`, `legal`, `pricing`, `pseo`, `status-page`, `tool`, `video` — see [@dualmark/converters](/docs/packages/converters). Or pass a custom function `(entry) => string`.
 
 ## Verify
 
@@ -174,12 +165,12 @@ Expect **120/125** under `next dev` (full Standard conformance).
 
 If you wired `@dualmark/core` into Next.js by hand before `@dualmark/nextjs` shipped, the migration is mechanical:
 
-| Before (`@dualmark/core` only) | After (`@dualmark/nextjs`) |
-|---|---|
-| Hand-rolled `proxy.ts`/`middleware.ts` with `detectAIBot` + `negotiateFormat` + manual rewrite logic | `createDualmarkMiddleware({ siteUrl })` |
-| Hand-rolled `app/md/[...path]/route.ts` with `if`-chains over the joined path | `createDualmarkRouteHandler({ siteUrl, collections, staticPages, parameterizedRoutes })` |
-| Hand-rolled `app/llms.txt/route.ts` calling `renderLlmsTxt` | `createLlmsTxtHandler({ brandName, sections })` |
-| Manual `transpilePackages: ["@dualmark/core", ...]` | `withDualmark(nextConfig, options)` |
+| Before (`@dualmark/core` only)                                                                       | After (`@dualmark/nextjs`)                                                               |
+| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Hand-rolled `proxy.ts`/`middleware.ts` with `detectAIBot` + `negotiateFormat` + manual rewrite logic | `createDualmarkMiddleware({ siteUrl })`                                                  |
+| Hand-rolled `app/md/[...path]/route.ts` with `if`-chains over the joined path                        | `createDualmarkRouteHandler({ siteUrl, collections, staticPages, parameterizedRoutes })` |
+| Hand-rolled `app/llms.txt/route.ts` calling `renderLlmsTxt`                                          | `createLlmsTxtHandler({ brandName, sections })`                                          |
+| Manual `transpilePackages: ["@dualmark/core", ...]`                                                  | `withDualmark(nextConfig, options)`                                                      |
 
 The internal namespace, response headers, and conformance score are unchanged. The reference example (`examples/nextjs-app-router`) is the canonical migration — it went from ~120 lines hand-rolled to ~50 lines with the adapter, same 120/125 score.
 

--- a/apps/docs/content/docs/packages/astro.mdx
+++ b/apps/docs/content/docs/packages/astro.mdx
@@ -4,9 +4,21 @@ description: Astro 5 integration — auto-generated .md routes, middleware, llms
 ---
 
 <Tabs items={["bun", "npm", "yarn"]}>
-  <Tab value="bun">```bash bun add @dualmark/astro @dualmark/core @dualmark/converters ```</Tab>
-  <Tab value="npm">```bash npm install @dualmark/astro @dualmark/core @dualmark/converters ```</Tab>
-  <Tab value="yarn">```bash yarn add @dualmark/astro @dualmark/core @dualmark/converters ```</Tab>
+<Tab value="bun">
+```bash
+bun add @dualmark/astro @dualmark/core @dualmark/converters
+```
+</Tab>
+<Tab value="npm">
+```bash
+npm install @dualmark/astro @dualmark/core @dualmark/converters
+```
+</Tab>
+<Tab value="yarn">
+```bash
+yarn add @dualmark/astro @dualmark/core @dualmark/converters
+```
+</Tab>
 </Tabs>
 
 ## `dualmark(config)`
@@ -18,11 +30,7 @@ import { defineConfig } from "astro/config";
 import dualmark from "@dualmark/astro";
 
 export default defineConfig({
-  integrations: [
-    dualmark({
-      /* config */
-    }),
-  ],
+  integrations: [dualmark({ /* config */ })],
 });
 ```
 
@@ -60,7 +68,7 @@ collections: {
     converter: "blog" | "case-study" | "changelog" | "compare" | "docs"
           | "feature" | "glossary" | "integration" | "legal" | "pricing" | "pseo"
           | "status-page" | "tool" | "video"
-          | ((entry) => string),  // or custom function
+              | ((entry) => string),  // or custom function
 
     slugStrategy?: "single" | "nested",  // single = /blog/<slug>, nested = /blog/<...>
 

--- a/apps/docs/content/docs/packages/astro.mdx
+++ b/apps/docs/content/docs/packages/astro.mdx
@@ -4,21 +4,9 @@ description: Astro 5 integration — auto-generated .md routes, middleware, llms
 ---
 
 <Tabs items={["bun", "npm", "yarn"]}>
-<Tab value="bun">
-```bash
-bun add @dualmark/astro @dualmark/core @dualmark/converters
-```
-</Tab>
-<Tab value="npm">
-```bash
-npm install @dualmark/astro @dualmark/core @dualmark/converters
-```
-</Tab>
-<Tab value="yarn">
-```bash
-yarn add @dualmark/astro @dualmark/core @dualmark/converters
-```
-</Tab>
+  <Tab value="bun">```bash bun add @dualmark/astro @dualmark/core @dualmark/converters ```</Tab>
+  <Tab value="npm">```bash npm install @dualmark/astro @dualmark/core @dualmark/converters ```</Tab>
+  <Tab value="yarn">```bash yarn add @dualmark/astro @dualmark/core @dualmark/converters ```</Tab>
 </Tabs>
 
 ## `dualmark(config)`
@@ -30,7 +18,11 @@ import { defineConfig } from "astro/config";
 import dualmark from "@dualmark/astro";
 
 export default defineConfig({
-  integrations: [dualmark({ /* config */ })],
+  integrations: [
+    dualmark({
+      /* config */
+    }),
+  ],
 });
 ```
 
@@ -66,9 +58,9 @@ interface DualmarkAstroConfig {
 collections: {
   blog: {
     converter: "blog" | "case-study" | "changelog" | "compare" | "docs"
-              | "feature" | "glossary" | "integration" | "legal" | "pricing" | "pseo"
-              | "tool" | "video"
-              | ((entry) => string),  // or custom function
+          | "feature" | "glossary" | "integration" | "legal" | "pricing" | "pseo"
+          | "status-page" | "tool" | "video"
+          | ((entry) => string),  // or custom function
 
     slugStrategy?: "single" | "nested",  // single = /blog/<slug>, nested = /blog/<...>
 

--- a/apps/docs/content/docs/packages/converters.mdx
+++ b/apps/docs/content/docs/packages/converters.mdx
@@ -1,34 +1,46 @@
 ---
 title: "@dualmark/converters"
-description: 14 production-tested markdown converter factories.
+description: Production-tested markdown converter factories.
 ---
 
 <Tabs items={["bun", "npm", "yarn"]}>
-  <Tab value="bun">```bash bun add @dualmark/converters @dualmark/core ```</Tab>
-  <Tab value="npm">```bash npm install @dualmark/converters @dualmark/core ```</Tab>
-  <Tab value="yarn">```bash yarn add @dualmark/converters @dualmark/core ```</Tab>
+<Tab value="bun">
+```bash
+bun add @dualmark/converters @dualmark/core
+```
+</Tab>
+<Tab value="npm">
+```bash
+npm install @dualmark/converters @dualmark/core
+```
+</Tab>
+<Tab value="yarn">
+```bash
+yarn add @dualmark/converters @dualmark/core
+```
+</Tab>
 </Tabs>
 
 Each factory takes a config object and returns `(entry: CollectionEntry<Data>) => string`.
 
 ## Available converters
 
-| Factory                | Domain                                                                    |
-| ---------------------- | ------------------------------------------------------------------------- |
-| `blogConverter`        | Blog posts                                                                |
-| `caseStudyConverter`   | Case studies (with stats + customer quote)                                |
-| `changelogConverter`   | Release notes (Keep-a-Changelog grouping)                                 |
-| `compareConverter`     | Comparison pages (us vs. competitor table)                                |
-| `docsConverter`        | Documentation pages                                                       |
-| `featureConverter`     | Feature/product pages with siblings, FAQ, problem/solution                |
-| `glossaryConverter`    | Glossary terms (with learn-more + canonical-blog)                         |
+| Factory | Domain |
+| --- | --- |
+| `blogConverter` | Blog posts |
+| `caseStudyConverter` | Case studies (with stats + customer quote) |
+| `changelogConverter` | Release notes (Keep-a-Changelog grouping) |
+| `compareConverter` | Comparison pages (us vs. competitor table) |
+| `docsConverter` | Documentation pages |
+| `featureConverter` | Feature/product pages with siblings, FAQ, problem/solution |
+| `glossaryConverter` | Glossary terms (with learn-more + canonical-blog) |
 | `integrationConverter` | Marketplace / app integration listings (vendor, categories, capabilities) |
-| `legalConverter`       | Legal pages                                                               |
-| `pricingConverter`     | Pricing tables with tier highlights and CTAs                              |
-| `pseoConverter`        | Programmatic SEO pages with facts + related-link groups                   |
-| `statusPageConverter`  | Public status / uptime pages (components + incidents)                     |
-| `toolConverter`        | Standalone tools                                                          |
-| `videoConverter`       | Video pages                                                               |
+| `legalConverter` | Legal pages |
+| `pricingConverter` | Pricing tables with tier highlights and CTAs |
+| `pseoConverter` | Programmatic SEO pages with facts + related-link groups |
+| `statusPageConverter` | Public status / uptime pages (components + incidents) |
+| `toolConverter` | Standalone tools |
+| `videoConverter` | Video pages |
 
 ## Common shape
 
@@ -59,8 +71,8 @@ const md = convert({
 
 ```ts
 interface BaseConverterConfig {
-  siteUrl: string; // required, used for absolute URLs
-  brandFooter?: string; // appended to every output
+  siteUrl: string;        // required, used for absolute URLs
+  brandFooter?: string;   // appended to every output
 }
 ```
 

--- a/apps/docs/content/docs/packages/converters.mdx
+++ b/apps/docs/content/docs/packages/converters.mdx
@@ -1,45 +1,34 @@
 ---
 title: "@dualmark/converters"
-description: 13 production-tested markdown converter factories.
+description: 14 production-tested markdown converter factories.
 ---
 
 <Tabs items={["bun", "npm", "yarn"]}>
-<Tab value="bun">
-```bash
-bun add @dualmark/converters @dualmark/core
-```
-</Tab>
-<Tab value="npm">
-```bash
-npm install @dualmark/converters @dualmark/core
-```
-</Tab>
-<Tab value="yarn">
-```bash
-yarn add @dualmark/converters @dualmark/core
-```
-</Tab>
+  <Tab value="bun">```bash bun add @dualmark/converters @dualmark/core ```</Tab>
+  <Tab value="npm">```bash npm install @dualmark/converters @dualmark/core ```</Tab>
+  <Tab value="yarn">```bash yarn add @dualmark/converters @dualmark/core ```</Tab>
 </Tabs>
 
 Each factory takes a config object and returns `(entry: CollectionEntry<Data>) => string`.
 
 ## Available converters
 
-| Factory | Domain |
-| --- | --- |
-| `blogConverter` | Blog posts |
-| `caseStudyConverter` | Case studies (with stats + customer quote) |
-| `changelogConverter` | Release notes (Keep-a-Changelog grouping) |
-| `compareConverter` | Comparison pages (us vs. competitor table) |
-| `docsConverter` | Documentation pages |
-| `featureConverter` | Feature/product pages with siblings, FAQ, problem/solution |
-| `glossaryConverter` | Glossary terms (with learn-more + canonical-blog) |
+| Factory                | Domain                                                                    |
+| ---------------------- | ------------------------------------------------------------------------- |
+| `blogConverter`        | Blog posts                                                                |
+| `caseStudyConverter`   | Case studies (with stats + customer quote)                                |
+| `changelogConverter`   | Release notes (Keep-a-Changelog grouping)                                 |
+| `compareConverter`     | Comparison pages (us vs. competitor table)                                |
+| `docsConverter`        | Documentation pages                                                       |
+| `featureConverter`     | Feature/product pages with siblings, FAQ, problem/solution                |
+| `glossaryConverter`    | Glossary terms (with learn-more + canonical-blog)                         |
 | `integrationConverter` | Marketplace / app integration listings (vendor, categories, capabilities) |
-| `legalConverter` | Legal pages |
-| `pricingConverter` | Pricing tables with tier highlights and CTAs |
-| `pseoConverter` | Programmatic SEO pages with facts + related-link groups |
-| `toolConverter` | Standalone tools |
-| `videoConverter` | Video pages |
+| `legalConverter`       | Legal pages                                                               |
+| `pricingConverter`     | Pricing tables with tier highlights and CTAs                              |
+| `pseoConverter`        | Programmatic SEO pages with facts + related-link groups                   |
+| `statusPageConverter`  | Public status / uptime pages (components + incidents)                     |
+| `toolConverter`        | Standalone tools                                                          |
+| `videoConverter`       | Video pages                                                               |
 
 ## Common shape
 
@@ -70,8 +59,8 @@ const md = convert({
 
 ```ts
 interface BaseConverterConfig {
-  siteUrl: string;        // required, used for absolute URLs
-  brandFooter?: string;   // appended to every output
+  siteUrl: string; // required, used for absolute URLs
+  brandFooter?: string; // appended to every output
 }
 ```
 

--- a/apps/docs/content/docs/packages/nextjs.mdx
+++ b/apps/docs/content/docs/packages/nextjs.mdx
@@ -4,21 +4,11 @@ description: Next.js App Router adapter — withDualmark, proxy/middleware facto
 ---
 
 <Tabs items={["bun", "npm", "yarn"]}>
-<Tab value="bun">
-```bash
-bun add @dualmark/nextjs @dualmark/core @dualmark/converters
-```
-</Tab>
-<Tab value="npm">
-```bash
-npm install @dualmark/nextjs @dualmark/core @dualmark/converters
-```
-</Tab>
-<Tab value="yarn">
-```bash
-yarn add @dualmark/nextjs @dualmark/core @dualmark/converters
-```
-</Tab>
+  <Tab value="bun">```bash bun add @dualmark/nextjs @dualmark/core @dualmark/converters ```</Tab>
+  <Tab value="npm">
+    ```bash npm install @dualmark/nextjs @dualmark/core @dualmark/converters ```
+  </Tab>
+  <Tab value="yarn">```bash yarn add @dualmark/nextjs @dualmark/core @dualmark/converters ```</Tab>
 </Tabs>
 
 ## `withDualmark(nextConfig, options)`
@@ -28,10 +18,7 @@ Wrap your Next.js config. Adds the dualmark workspace packages to `transpilePack
 ```ts title="next.config.mjs"
 import { withDualmark } from "@dualmark/nextjs";
 
-export default withDualmark(
-  { reactStrictMode: true },
-  { siteUrl: "https://example.com" },
-);
+export default withDualmark({ reactStrictMode: true }, { siteUrl: "https://example.com" });
 ```
 
 ## `createDualmarkMiddleware(options)`
@@ -66,7 +53,8 @@ The middleware:
 - Adds `Link: <…>; rel="alternate"; type="text/markdown"` and `Vary: Accept` to HTML responses
 
 <Callout>
-  The matcher must be an inline literal — Next.js statically parses `export const config` and rejects imports/expressions. If you customize `internalNamespace`, replace `md/` accordingly.
+  The matcher must be an inline literal — Next.js statically parses `export const config` and
+  rejects imports/expressions. If you customize `internalNamespace`, replace `md/` accordingly.
 </Callout>
 
 ## `createDualmarkRouteHandler(options)`
@@ -93,10 +81,7 @@ const handler = createDualmarkRouteHandler({
   parameterizedRoutes: [
     {
       pattern: "/tax/[country]",
-      getStaticPaths: () => [
-        { params: { country: "us" } },
-        { params: { country: "uk" } },
-      ],
+      getStaticPaths: () => [{ params: { country: "us" } }, { params: { country: "uk" } }],
       render: ({ params }) => `# Tax: ${params.country.toUpperCase()}`,
     },
   ],
@@ -137,7 +122,7 @@ export const GET = handler.GET;
 ```ts
 interface DualmarkNextConfig {
   siteUrl: string;
-  internalNamespace?: string;          // default "md"
+  internalNamespace?: string; // default "md"
 
   collections?: Record<string, CollectionConfig>;
   staticPages?: StaticPageConfig[];
@@ -151,13 +136,13 @@ interface DualmarkNextConfig {
   };
 
   middleware?: {
-    injectLinkHeader?: boolean;        // default true
+    injectLinkHeader?: boolean; // default true
     skipPaths?: ReadonlyArray<string>; // additional path prefixes the middleware ignores
   };
 
   headers?: {
-    cacheControl?: string;             // default "public, max-age=3600"
-    noindex?: boolean;                 // default true
+    cacheControl?: string; // default "public, max-age=3600"
+    noindex?: boolean; // default true
   };
 }
 ```
@@ -170,7 +155,7 @@ collections: {
     converter:
       | "blog" | "case-study" | "changelog" | "compare" | "docs"
       | "feature" | "glossary" | "integration" | "legal" | "pricing" | "pseo"
-      | "tool" | "video"
+      | "status-page" | "tool" | "video"
       | ((entry) => string),
 
     getEntries: () => Entry[] | Promise<Entry[]>,
@@ -191,7 +176,9 @@ For each collection, the route handler emits:
 - `/<collection>` listing (unless `emitListing: false`)
 
 <Callout>
-  Unlike Astro's `astro:content`, Next.js has no built-in content discovery, so you supply `getEntries`. The function may be sync or async — read from the filesystem, a CMS, a database, anything.
+  Unlike Astro's `astro:content`, Next.js has no built-in content discovery, so you supply
+  `getEntries`. The function may be sync or async — read from the filesystem, a CMS, a database,
+  anything.
 </Callout>
 
 ### Static pages
@@ -200,7 +187,7 @@ For each collection, the route handler emits:
 staticPages: [
   { pattern: "/", render: () => "# Home\n\nWelcome." },
   { pattern: "/about", render: () => "# About" },
-]
+];
 ```
 
 Generates `/index.md` and `/about.md` (served via the `/md/index` and `/md/about` rewrites).
@@ -211,13 +198,10 @@ Generates `/index.md` and `/about.md` (served via the `/md/index` and `/md/about
 parameterizedRoutes: [
   {
     pattern: "/tax/[country]",
-    getStaticPaths: async () => [
-      { params: { country: "us" } },
-      { params: { country: "uk" } },
-    ],
+    getStaticPaths: async () => [{ params: { country: "us" } }, { params: { country: "uk" } }],
     render: ({ params }) => `# Tax in ${params.country.toUpperCase()}`,
   },
-]
+];
 ```
 
 Generates `/tax/us.md`, `/tax/uk.md`.

--- a/apps/docs/content/docs/packages/nextjs.mdx
+++ b/apps/docs/content/docs/packages/nextjs.mdx
@@ -4,11 +4,21 @@ description: Next.js App Router adapter — withDualmark, proxy/middleware facto
 ---
 
 <Tabs items={["bun", "npm", "yarn"]}>
-  <Tab value="bun">```bash bun add @dualmark/nextjs @dualmark/core @dualmark/converters ```</Tab>
-  <Tab value="npm">
-    ```bash npm install @dualmark/nextjs @dualmark/core @dualmark/converters ```
-  </Tab>
-  <Tab value="yarn">```bash yarn add @dualmark/nextjs @dualmark/core @dualmark/converters ```</Tab>
+<Tab value="bun">
+```bash
+bun add @dualmark/nextjs @dualmark/core @dualmark/converters
+```
+</Tab>
+<Tab value="npm">
+```bash
+npm install @dualmark/nextjs @dualmark/core @dualmark/converters
+```
+</Tab>
+<Tab value="yarn">
+```bash
+yarn add @dualmark/nextjs @dualmark/core @dualmark/converters
+```
+</Tab>
 </Tabs>
 
 ## `withDualmark(nextConfig, options)`
@@ -18,7 +28,10 @@ Wrap your Next.js config. Adds the dualmark workspace packages to `transpilePack
 ```ts title="next.config.mjs"
 import { withDualmark } from "@dualmark/nextjs";
 
-export default withDualmark({ reactStrictMode: true }, { siteUrl: "https://example.com" });
+export default withDualmark(
+  { reactStrictMode: true },
+  { siteUrl: "https://example.com" },
+);
 ```
 
 ## `createDualmarkMiddleware(options)`
@@ -53,8 +66,7 @@ The middleware:
 - Adds `Link: <…>; rel="alternate"; type="text/markdown"` and `Vary: Accept` to HTML responses
 
 <Callout>
-  The matcher must be an inline literal — Next.js statically parses `export const config` and
-  rejects imports/expressions. If you customize `internalNamespace`, replace `md/` accordingly.
+  The matcher must be an inline literal — Next.js statically parses `export const config` and rejects imports/expressions. If you customize `internalNamespace`, replace `md/` accordingly.
 </Callout>
 
 ## `createDualmarkRouteHandler(options)`
@@ -81,7 +93,10 @@ const handler = createDualmarkRouteHandler({
   parameterizedRoutes: [
     {
       pattern: "/tax/[country]",
-      getStaticPaths: () => [{ params: { country: "us" } }, { params: { country: "uk" } }],
+      getStaticPaths: () => [
+        { params: { country: "us" } },
+        { params: { country: "uk" } },
+      ],
       render: ({ params }) => `# Tax: ${params.country.toUpperCase()}`,
     },
   ],
@@ -122,7 +137,7 @@ export const GET = handler.GET;
 ```ts
 interface DualmarkNextConfig {
   siteUrl: string;
-  internalNamespace?: string; // default "md"
+  internalNamespace?: string;          // default "md"
 
   collections?: Record<string, CollectionConfig>;
   staticPages?: StaticPageConfig[];
@@ -136,13 +151,13 @@ interface DualmarkNextConfig {
   };
 
   middleware?: {
-    injectLinkHeader?: boolean; // default true
+    injectLinkHeader?: boolean;        // default true
     skipPaths?: ReadonlyArray<string>; // additional path prefixes the middleware ignores
   };
 
   headers?: {
-    cacheControl?: string; // default "public, max-age=3600"
-    noindex?: boolean; // default true
+    cacheControl?: string;             // default "public, max-age=3600"
+    noindex?: boolean;                 // default true
   };
 }
 ```
@@ -176,9 +191,7 @@ For each collection, the route handler emits:
 - `/<collection>` listing (unless `emitListing: false`)
 
 <Callout>
-  Unlike Astro's `astro:content`, Next.js has no built-in content discovery, so you supply
-  `getEntries`. The function may be sync or async — read from the filesystem, a CMS, a database,
-  anything.
+  Unlike Astro's `astro:content`, Next.js has no built-in content discovery, so you supply `getEntries`. The function may be sync or async — read from the filesystem, a CMS, a database, anything.
 </Callout>
 
 ### Static pages
@@ -187,7 +200,7 @@ For each collection, the route handler emits:
 staticPages: [
   { pattern: "/", render: () => "# Home\n\nWelcome." },
   { pattern: "/about", render: () => "# About" },
-];
+]
 ```
 
 Generates `/index.md` and `/about.md` (served via the `/md/index` and `/md/about` rewrites).
@@ -198,10 +211,13 @@ Generates `/index.md` and `/about.md` (served via the `/md/index` and `/md/about
 parameterizedRoutes: [
   {
     pattern: "/tax/[country]",
-    getStaticPaths: async () => [{ params: { country: "us" } }, { params: { country: "uk" } }],
+    getStaticPaths: async () => [
+      { params: { country: "us" } },
+      { params: { country: "uk" } },
+    ],
     render: ({ params }) => `# Tax in ${params.country.toUpperCase()}`,
   },
-];
+]
 ```
 
 Generates `/tax/us.md`, `/tax/uk.md`.

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -75,7 +75,7 @@ export default defineConfig({
 
 ## Built-in converter names
 
-`blog`, `case-study`, `changelog`, `compare`, `docs`, `feature`, `glossary`, `legal`, `pricing`, `pseo`, `tool`, `video`
+`blog`, `case-study`, `changelog`, `compare`, `docs`, `feature`, `glossary`, `legal`, `pricing`, `pseo`, `status-page`, `tool`, `video`
 
 Pass any string from this list as `converter`, or pass a function (currently not serializable into generated routes — planned for a future release).
 

--- a/packages/astro/src/converter-registry.ts
+++ b/packages/astro/src/converter-registry.ts
@@ -10,6 +10,7 @@ import {
   legalConverter,
   pricingConverter,
   pseoConverter,
+  statusPageConverter,
   toolConverter,
   videoConverter,
   type BaseConverterConfig,
@@ -29,6 +30,7 @@ export type BuiltInConverterName =
   | "legal"
   | "pricing"
   | "pseo"
+  | "status-page"
   | "tool"
   | "video";
 
@@ -51,7 +53,9 @@ export function resolveBuiltInConverter(
     case "changelog":
       return changelogConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "compare":
-      return compareConverter({ ...cfg, ourBrandColumn: "Us" }) as Converter<CollectionEntry<unknown>>;
+      return compareConverter({ ...cfg, ourBrandColumn: "Us" }) as Converter<
+        CollectionEntry<unknown>
+      >;
     case "docs":
       return docsConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "feature":
@@ -66,13 +70,15 @@ export function resolveBuiltInConverter(
       return pricingConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "pseo":
       return pseoConverter(cfg) as Converter<CollectionEntry<unknown>>;
+    case "status-page":
+      return statusPageConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "tool":
       return toolConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "video":
       return videoConverter(cfg) as Converter<CollectionEntry<unknown>>;
     default:
       throw new Error(
-        `Dualmark: unknown built-in converter '${args.name}'. Valid names: blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, tool, video. Or pass a function.`,
+        `Dualmark: unknown built-in converter '${args.name}'. Valid names: blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, status-page, tool, video. Or pass a function.`,
       );
   }
 }

--- a/packages/astro/test/integration.test.ts
+++ b/packages/astro/test/integration.test.ts
@@ -197,4 +197,24 @@ describe("converter-registry resolveBuiltInConverter", () => {
     });
     expect(out).toContain("# X");
   });
+
+  it("returns a callable converter for 'status-page'", async () => {
+    const { resolveBuiltInConverter } = await import("../src/converter-registry.js");
+    const conv = resolveBuiltInConverter({
+      name: "status-page",
+      collectionName: "status",
+      baseConfig: { siteUrl: "https://example.com" },
+    });
+    const out = conv({
+      id: "main",
+      data: {
+        title: "System Status",
+        url: "https://status.example.com",
+        overall: "operational",
+        components: [],
+      },
+    } as never);
+    expect(out).toContain("# System Status");
+    expect(out).toContain("No incidents reported.");
+  });
 });

--- a/packages/converters/README.md
+++ b/packages/converters/README.md
@@ -23,6 +23,7 @@ bun add @dualmark/converters @dualmark/core
 | `legalConverter` | Legal pages |
 | `pricingConverter` | Pricing tables with tier highlights and CTAs |
 | `pseoConverter` | Programmatic SEO pages with facts + related-link groups |
+| `statusPageConverter` | Public status / uptime pages (components + incidents) |
 | `toolConverter` | Standalone tools |
 | `videoConverter` | Video pages |
 

--- a/packages/converters/package.json
+++ b/packages/converters/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dualmark/converters",
   "version": "0.5.2",
-  "description": "14 production-tested markdown converter factories (blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, status-page, tool, video) for the Dualmark AEO framework.",
+  "description": "Production-tested markdown converter factories (blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, status-page, tool, video) for the Dualmark AEO framework.",
   "license": "Apache-2.0",
   "author": "Dodo Payments <opensource@dodopayments.com> (https://dodopayments.com)",
   "repository": {

--- a/packages/converters/package.json
+++ b/packages/converters/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@dualmark/converters",
   "version": "0.5.2",
-  "description": "13 production-tested markdown converter factories (blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, tool, video) for the Dualmark AEO framework.",
+<<<<<<< HEAD
+  "description": "14 production-tested markdown converter factories (blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, status-page, tool, video) for the Dualmark AEO framework.",
   "license": "Apache-2.0",
   "author": "Dodo Payments <opensource@dodopayments.com> (https://dodopayments.com)",
   "repository": {

--- a/packages/converters/package.json
+++ b/packages/converters/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@dualmark/converters",
   "version": "0.5.2",
-<<<<<<< HEAD
   "description": "14 production-tested markdown converter factories (blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, status-page, tool, video) for the Dualmark AEO framework.",
   "license": "Apache-2.0",
   "author": "Dodo Payments <opensource@dodopayments.com> (https://dodopayments.com)",

--- a/packages/converters/src/index.ts
+++ b/packages/converters/src/index.ts
@@ -15,11 +15,7 @@ export {
   type IntegrationEntryData,
 } from "./integration.js";
 export { legalConverter, type LegalConverterConfig, type LegalEntryData } from "./legal.js";
-export {
-  compareConverter,
-  type CompareConverterConfig,
-  type CompareEntryData,
-} from "./compare.js";
+export { compareConverter, type CompareConverterConfig, type CompareEntryData } from "./compare.js";
 export { toolConverter, type ToolConverterConfig, type ToolEntryData } from "./tool.js";
 export { videoConverter, type VideoConverterConfig, type VideoEntryData } from "./video.js";
 export {
@@ -43,6 +39,14 @@ export {
   type ChangelogChange,
   type ChangelogChangeType,
 } from "./changelog.js";
+export {
+  statusPageConverter,
+  type StatusPageConverterConfig,
+  type StatusPageEntryData,
+  type StatusPageComponent,
+  type StatusPageIncident,
+  type StatusPageOverallStatus,
+} from "./status-page.js";
 export {
   pricingConverter,
   type PricingConverterConfig,
@@ -71,6 +75,7 @@ export const BUILT_IN_CONVERTERS = [
   "legal",
   "pricing",
   "pseo",
+  "status-page",
   "tool",
   "video",
 ] as const;

--- a/packages/converters/src/status-page.ts
+++ b/packages/converters/src/status-page.ts
@@ -123,7 +123,7 @@ export function statusPageConverter(
       "\n## Components\n\n" +
         (components.length > 0 ? components.join("\n") : "No components listed."),
       incidentsSection,
-      "\n---",
+      entry.body && "\n---",
       entry.body && `\n${cleanBody(entry.body)}`,
       config.brandFooter && "\n---",
       config.brandFooter && `\n${config.brandFooter}`,

--- a/packages/converters/src/status-page.ts
+++ b/packages/converters/src/status-page.ts
@@ -20,11 +20,15 @@ export interface StatusPageIncident {
   summary: string;
 }
 
-export interface StatusPageConverterConfig extends BaseConverterConfig {}
+export interface StatusPageConverterConfig extends BaseConverterConfig {
+  /** Collection URL prefix (e.g. `/status`). Set automatically by framework adapters. */
+  basePath?: string;
+}
 
 export interface StatusPageEntryData {
   title: string;
-  url: string;
+  /** Canonical status page URL. When omitted or blank, defaults to `siteUrl + basePath + / + entry.id`. */
+  url?: string;
   overall: StatusPageOverallStatus;
   components: StatusPageComponent[];
   incidents?: StatusPageIncident[];
@@ -72,6 +76,14 @@ export function statusPageConverter(
   return (entry) => {
     const d = entry.data;
     const overallLabel = OVERALL_LABEL[d.overall];
+    const basePathTrim = config.basePath?.replace(/\/$/, "") ?? "";
+    const site = config.siteUrl.replace(/\/$/, "");
+    const resolvedUrl =
+      d.url !== undefined && d.url.trim() !== ""
+        ? d.url
+        : basePathTrim
+          ? `${site}${basePathTrim.startsWith("/") ? basePathTrim : `/${basePathTrim}`}/${entry.id}`
+          : `${site}/${entry.id}`;
 
     const components = d.components.map((component) => {
       const uptime =
@@ -105,10 +117,9 @@ export function statusPageConverter(
 
     const md = joinLines(
       `# ${d.title}`,
-      `\n> ${overallLabel}`,
-      "",
+      `\n> ${overallLabel}\n`,
       `- **Overall**: ${overallLabel}`,
-      `- **URL**: ${d.url}`,
+      `- **URL**: ${resolvedUrl}`,
       "\n## Components\n\n" +
         (components.length > 0 ? components.join("\n") : "No components listed."),
       incidentsSection,

--- a/packages/converters/src/status-page.ts
+++ b/packages/converters/src/status-page.ts
@@ -99,7 +99,7 @@ export function statusPageConverter(
       const key: IncidentGroup = incident.resolved ? "resolved" : "ongoing";
       const list = grouped.get(key) ?? [];
       const date = formatIncidentDate(incident.date);
-      list.push(`- **${incident.title}** (${date}) -- ${incident.summary}`);
+      list.push(`- **${incident.title}** (${date}): ${incident.summary}`);
       grouped.set(key, list);
     }
 
@@ -109,7 +109,7 @@ export function statusPageConverter(
       for (const key of INCIDENT_ORDER) {
         const items = grouped.get(key);
         if (items && items.length > 0) {
-          sections.push(`\n### ${INCIDENT_HEADING[key]}\n\n${items.join("\n")}`);
+          sections.push(`\n\n### ${INCIDENT_HEADING[key]}\n\n${items.join("\n")}`);
         }
       }
       incidentsSection = `\n## Incidents${sections.join("")}`;

--- a/packages/converters/src/status-page.ts
+++ b/packages/converters/src/status-page.ts
@@ -1,0 +1,123 @@
+import { cleanBody, fmtDate, joinLines, normalizeUnicode } from "@dualmark/core";
+import type { BaseConverterConfig, CollectionEntry, Converter } from "./types.js";
+
+export type StatusPageOverallStatus =
+  | "operational"
+  | "degraded"
+  | "partial-outage"
+  | "major-outage";
+
+export interface StatusPageComponent {
+  name: string;
+  status: string;
+  uptime90d?: number;
+}
+
+export interface StatusPageIncident {
+  title: string;
+  date: string;
+  resolved: boolean;
+  summary: string;
+}
+
+export interface StatusPageConverterConfig extends BaseConverterConfig {}
+
+export interface StatusPageEntryData {
+  title: string;
+  url: string;
+  overall: StatusPageOverallStatus;
+  components: StatusPageComponent[];
+  incidents?: StatusPageIncident[];
+}
+
+type IncidentGroup = "ongoing" | "resolved";
+
+const OVERALL_LABEL: Record<StatusPageOverallStatus, string> = {
+  operational: "Operational",
+  degraded: "Degraded",
+  "partial-outage": "Partial outage",
+  "major-outage": "Major outage",
+};
+
+const INCIDENT_ORDER: IncidentGroup[] = ["ongoing", "resolved"];
+const INCIDENT_HEADING: Record<IncidentGroup, string> = {
+  ongoing: "Ongoing incidents",
+  resolved: "Resolved incidents",
+};
+
+function formatUptime90d(uptime: number): string {
+  if (!Number.isFinite(uptime)) return String(uptime);
+  return `${uptime.toFixed(2)}%`;
+}
+
+function formatIncidentDate(date: string): string {
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return date;
+  return fmtDate(parsed);
+}
+
+function sortIncidentsNewestFirst(incidents: StatusPageIncident[]): StatusPageIncident[] {
+  return [...incidents].sort((a, b) => {
+    const aTime = new Date(a.date).getTime();
+    const bTime = new Date(b.date).getTime();
+    const aVal = Number.isNaN(aTime) ? -Infinity : aTime;
+    const bVal = Number.isNaN(bTime) ? -Infinity : bTime;
+    return bVal - aVal;
+  });
+}
+
+export function statusPageConverter(
+  config: StatusPageConverterConfig,
+): Converter<CollectionEntry<StatusPageEntryData>> {
+  return (entry) => {
+    const d = entry.data;
+    const overallLabel = OVERALL_LABEL[d.overall];
+
+    const components = d.components.map((component) => {
+      const uptime =
+        typeof component.uptime90d === "number"
+          ? ` (90d uptime ${formatUptime90d(component.uptime90d)})`
+          : "";
+      return `- **${component.name}**: ${component.status}${uptime}`;
+    });
+
+    const incidents = sortIncidentsNewestFirst(d.incidents ?? []);
+    const grouped = new Map<IncidentGroup, string[]>();
+    for (const incident of incidents) {
+      const key: IncidentGroup = incident.resolved ? "resolved" : "ongoing";
+      const list = grouped.get(key) ?? [];
+      const date = formatIncidentDate(incident.date);
+      list.push(`- **${incident.title}** (${date}) -- ${incident.summary}`);
+      grouped.set(key, list);
+    }
+
+    let incidentsSection = "\n## Incidents\n\nNo incidents reported.";
+    if (incidents.length > 0) {
+      const sections: string[] = [];
+      for (const key of INCIDENT_ORDER) {
+        const items = grouped.get(key);
+        if (items && items.length > 0) {
+          sections.push(`\n### ${INCIDENT_HEADING[key]}\n\n${items.join("\n")}`);
+        }
+      }
+      incidentsSection = `\n## Incidents${sections.join("")}`;
+    }
+
+    const md = joinLines(
+      `# ${d.title}`,
+      `\n> ${overallLabel}`,
+      "",
+      `- **Overall**: ${overallLabel}`,
+      `- **URL**: ${d.url}`,
+      "\n## Components\n\n" +
+        (components.length > 0 ? components.join("\n") : "No components listed."),
+      incidentsSection,
+      "\n---",
+      entry.body && `\n${cleanBody(entry.body)}`,
+      config.brandFooter && "\n---",
+      config.brandFooter && `\n${config.brandFooter}`,
+    );
+
+    return normalizeUnicode(md);
+  };
+}

--- a/packages/converters/test/__snapshots__/status-page.test.ts.snap
+++ b/packages/converters/test/__snapshots__/status-page.test.ts.snap
@@ -4,6 +4,7 @@ exports[`statusPageConverter > renders a realistic status page snapshot 1`] = `
 "# Acme Cloud Status
 
 > Degraded
+
 - **Overall**: Degraded
 - **URL**: https://status.acme.test
 
@@ -22,6 +23,44 @@ exports[`statusPageConverter > renders a realistic status page snapshot 1`] = `
 
 - **Scheduled database maintenance** (2026-05-02) -- Maintenance completed; replicas are healthy.
 - **Billing webhook delays** (2026-04-25) -- Queue backlog cleared and processing is stable.
+
+---"
+`;
+
+exports[`statusPageConverter > renders components with no incidents (empty incidents array) 1`] = `
+"# Platform status
+
+> Operational
+
+- **Overall**: Operational
+- **URL**: https://status.example.com
+
+## Components
+
+- **API**: operational (90d uptime 99.90%)
+
+## Incidents
+
+No incidents reported.
+
+---"
+`;
+
+exports[`statusPageConverter > renders minimal entry data (no url, no incidents, no components) 1`] = `
+"# Service status
+
+> Operational
+
+- **Overall**: Operational
+- **URL**: https://acme.test/svc
+
+## Components
+
+No components listed.
+
+## Incidents
+
+No incidents reported.
 
 ---"
 `;

--- a/packages/converters/test/__snapshots__/status-page.test.ts.snap
+++ b/packages/converters/test/__snapshots__/status-page.test.ts.snap
@@ -1,0 +1,27 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`statusPageConverter > renders a realistic status page snapshot 1`] = `
+"# Acme Cloud Status
+
+> Degraded
+- **Overall**: Degraded
+- **URL**: https://status.acme.test
+
+## Components
+
+- **API**: degraded (90d uptime 99.72%)
+- **Edge Network**: operational (90d uptime 99.99%)
+- **Web Dashboard**: operational
+- **Billing**: partial outage (90d uptime 98.88%)
+
+## Incidents
+### Ongoing incidents
+
+- **Intermittent 5xx responses** (2026-05-08) -- We are investigating elevated error rates on API writes.
+### Resolved incidents
+
+- **Scheduled database maintenance** (2026-05-02) -- Maintenance completed; replicas are healthy.
+- **Billing webhook delays** (2026-04-25) -- Queue backlog cleared and processing is stable.
+
+---"
+`;

--- a/packages/converters/test/__snapshots__/status-page.test.ts.snap
+++ b/packages/converters/test/__snapshots__/status-page.test.ts.snap
@@ -24,9 +24,7 @@ exports[`statusPageConverter > renders a realistic status page snapshot 1`] = `
 ### Resolved incidents
 
 - **Scheduled database maintenance** (2026-05-02): Maintenance completed; replicas are healthy.
-- **Billing webhook delays** (2026-04-25): Queue backlog cleared and processing is stable.
-
----"
+- **Billing webhook delays** (2026-04-25): Queue backlog cleared and processing is stable."
 `;
 
 exports[`statusPageConverter > renders components with no incidents (empty incidents array) 1`] = `
@@ -43,9 +41,7 @@ exports[`statusPageConverter > renders components with no incidents (empty incid
 
 ## Incidents
 
-No incidents reported.
-
----"
+No incidents reported."
 `;
 
 exports[`statusPageConverter > renders minimal entry data (no url, no incidents, no components) 1`] = `
@@ -62,7 +58,5 @@ No components listed.
 
 ## Incidents
 
-No incidents reported.
-
----"
+No incidents reported."
 `;

--- a/packages/converters/test/__snapshots__/status-page.test.ts.snap
+++ b/packages/converters/test/__snapshots__/status-page.test.ts.snap
@@ -16,13 +16,15 @@ exports[`statusPageConverter > renders a realistic status page snapshot 1`] = `
 - **Billing**: partial outage (90d uptime 98.88%)
 
 ## Incidents
+
 ### Ongoing incidents
 
-- **Intermittent 5xx responses** (2026-05-08) -- We are investigating elevated error rates on API writes.
+- **Intermittent 5xx responses** (2026-05-08): We are investigating elevated error rates on API writes.
+
 ### Resolved incidents
 
-- **Scheduled database maintenance** (2026-05-02) -- Maintenance completed; replicas are healthy.
-- **Billing webhook delays** (2026-04-25) -- Queue backlog cleared and processing is stable.
+- **Scheduled database maintenance** (2026-05-02): Maintenance completed; replicas are healthy.
+- **Billing webhook delays** (2026-04-25): Queue backlog cleared and processing is stable.
 
 ---"
 `;

--- a/packages/converters/test/converters.test.ts
+++ b/packages/converters/test/converters.test.ts
@@ -40,9 +40,7 @@ describe("blogConverter", () => {
     expect(out).toContain("- **Published**: 2026-05-01");
     expect(out).toContain("- **URL**: https://acme.test/blog/first-post");
     expect(out).toContain("Hello world.");
-    expect(out).toContain(
-      "[More engineering articles](https://acme.test/blog/category/engineering)",
-    );
+    expect(out).toContain("[More engineering articles](https://acme.test/blog/category/engineering)");
     expect(out).toContain("[All articles](https://acme.test/blog)");
   });
 
@@ -613,7 +611,7 @@ describe("docsConverter", () => {
 });
 
 describe("BUILT_IN_CONVERTERS export", () => {
-  it("lists all 13 generic built-in names in alphabetical order", () => {
+  it("lists all built-in names in alphabetical order", () => {
     expect(BUILT_IN_CONVERTERS).toEqual([
       "blog",
       "case-study",

--- a/packages/converters/test/converters.test.ts
+++ b/packages/converters/test/converters.test.ts
@@ -40,7 +40,9 @@ describe("blogConverter", () => {
     expect(out).toContain("- **Published**: 2026-05-01");
     expect(out).toContain("- **URL**: https://acme.test/blog/first-post");
     expect(out).toContain("Hello world.");
-    expect(out).toContain("[More engineering articles](https://acme.test/blog/category/engineering)");
+    expect(out).toContain(
+      "[More engineering articles](https://acme.test/blog/category/engineering)",
+    );
     expect(out).toContain("[All articles](https://acme.test/blog)");
   });
 
@@ -624,6 +626,7 @@ describe("BUILT_IN_CONVERTERS export", () => {
       "legal",
       "pricing",
       "pseo",
+      "status-page",
       "tool",
       "video",
     ]);

--- a/packages/converters/test/status-page.test.ts
+++ b/packages/converters/test/status-page.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { statusPageConverter } from "../src/index.js";
+
+const convert = statusPageConverter({ siteUrl: "https://acme.test" });
+
+describe("statusPageConverter", () => {
+  it("renders a realistic status page snapshot", () => {
+    const out = convert({
+      id: "acme-cloud",
+      data: {
+        title: "Acme Cloud Status",
+        url: "https://status.acme.test",
+        overall: "degraded",
+        components: [
+          { name: "API", status: "degraded", uptime90d: 99.72 },
+          { name: "Edge Network", status: "operational", uptime90d: 99.99 },
+          { name: "Web Dashboard", status: "operational" },
+          { name: "Billing", status: "partial outage", uptime90d: 98.88 },
+        ],
+        incidents: [
+          {
+            title: "Intermittent 5xx responses",
+            date: "2026-05-08T14:12:00Z",
+            resolved: false,
+            summary: "We are investigating elevated error rates on API writes.",
+          },
+          {
+            title: "Scheduled database maintenance",
+            date: "2026-05-02T03:00:00Z",
+            resolved: true,
+            summary: "Maintenance completed; replicas are healthy.",
+          },
+          {
+            title: "Billing webhook delays",
+            date: "2026-04-25T21:45:00Z",
+            resolved: true,
+            summary: "Queue backlog cleared and processing is stable.",
+          },
+        ],
+      },
+    });
+
+    expect(out).toMatchSnapshot();
+  });
+});

--- a/packages/converters/test/status-page.test.ts
+++ b/packages/converters/test/status-page.test.ts
@@ -42,4 +42,32 @@ describe("statusPageConverter", () => {
 
     expect(out).toMatchSnapshot();
   });
+
+  it("renders minimal entry data (no url, no incidents, no components)", () => {
+    const out = convert({
+      id: "svc",
+      data: {
+        title: "Service status",
+        overall: "operational",
+        components: [],
+      },
+    });
+
+    expect(out).toMatchSnapshot();
+  });
+
+  it("renders components with no incidents (empty incidents array)", () => {
+    const out = convert({
+      id: "platform",
+      data: {
+        title: "Platform status",
+        url: "https://status.example.com",
+        overall: "operational",
+        components: [{ name: "API", status: "operational", uptime90d: 99.9 }],
+        incidents: [],
+      },
+    });
+
+    expect(out).toMatchSnapshot();
+  });
 });

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -108,7 +108,7 @@ different name.
 ## Built-in converter names
 
 `blog`, `case-study`, `changelog`, `compare`, `docs`, `feature`, `glossary`,
-`legal`, `pricing`, `pseo`, `tool`, `video`. Pass any of them as `converter`,
+`legal`, `pricing`, `pseo`, `status-page`, `tool`, `video`. Pass any of them as `converter`,
 or pass a function `(entry) => string` for custom output.
 
 ## Why Next.js needs `getEntries`

--- a/packages/nextjs/src/converter-registry.ts
+++ b/packages/nextjs/src/converter-registry.ts
@@ -15,6 +15,7 @@ import {
   legalConverter,
   pricingConverter,
   pseoConverter,
+  statusPageConverter,
   toolConverter,
   videoConverter,
   type BaseConverterConfig,
@@ -34,6 +35,7 @@ export type BuiltInConverterName =
   | "legal"
   | "pricing"
   | "pseo"
+  | "status-page"
   | "tool"
   | "video";
 
@@ -73,13 +75,16 @@ export function resolveBuiltInConverter(
       return pricingConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "pseo":
       return pseoConverter(cfg) as Converter<CollectionEntry<unknown>>;
+    case "status-page":
+      return statusPageConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "tool":
       return toolConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "video":
       return videoConverter(cfg) as Converter<CollectionEntry<unknown>>;
     default:
       throw new Error(
-        `Dualmark: unknown built-in converter '${args.name}'. Valid names: blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, tool, video. Or pass a function.`,
+<<<<<<< HEAD
+        `Dualmark: unknown built-in converter '${args.name}'. Valid names: blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, status-page, tool, video. Or pass a function.`,
       );
   }
 }

--- a/packages/nextjs/src/converter-registry.ts
+++ b/packages/nextjs/src/converter-registry.ts
@@ -83,7 +83,6 @@ export function resolveBuiltInConverter(
       return videoConverter(cfg) as Converter<CollectionEntry<unknown>>;
     default:
       throw new Error(
-<<<<<<< HEAD
         `Dualmark: unknown built-in converter '${args.name}'. Valid names: blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, status-page, tool, video. Or pass a function.`,
       );
   }


### PR DESCRIPTION
## Summary

Add a status page converter for uptime/status pages with clean, chat-friendly output.

## Changes

- Add `statusPageConverter` with component/incident formatting and timeline ordering.
- Export new converter and include `status-page` in built-in list.
- Add snapshot test with realistic fixture.

## Type

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change
- [ ] Spec change (requires bump in `AEO_SPEC_VERSION`)
- [ ] Docs / examples / tooling only

## Verification

- [x] `bun run build` passes
- [x] `bun run test` passes
- [x] `bun run typecheck` passes
- [ ] If touching examples: ran `dualmark verify` against the example end-to-end
- [ ] If touching `/spec/`: ran `bun run --filter dualmark-docs sync-spec` and committed the mirror

## Changeset

- [x] Added a changeset (`bun run changeset`) for any package with a user-visible change

Closes #12