### PR TITLE
feat(core): extend AI bot detection list

### DIFF
--- a/.changeset/extend-ai-bot-registry.md
+++ b/.changeset/extend-ai-bot-registry.md
@@ -1,0 +1,5 @@
+---
+"@dualmark/core": patch
+---
+
+Extend the AI crawler registry with DeepSeekBot, Claude-SearchBot, Claude-User, Meta-ExternalFetcher, and Perplexity-User. Sync the AEO spec AI Agent Registry table.

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Plus:
 
 | Surface | Status |
 |---|---|
-| `@dualmark/core` | 172 tests pass (vitest + fast-check property tests) |
+| `@dualmark/core` | 174 tests pass (vitest + fast-check property tests) |
 | `@dualmark/converters` | 24 tests pass |
 | `@dualmark/cloudflare` | 23 tests pass |
 | `@dualmark/cli` | 17 tests pass |
@@ -272,7 +272,7 @@ Plus:
 
 ```bash
 bun install
-bun run build && bun run test && bun run typecheck   # 318 tests across 6 packages
+bun run build && bun run test && bun run typecheck   # 320 tests across 6 packages
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ yourcompany.com/llms.txt            ← AI agents discover everything
 
 Same URL. Same content. Different rendering. Picked automatically by:
 - `Accept: text/markdown` header → markdown
-- Known AI bot User-Agent (GPTBot, ClaudeBot, PerplexityBot, +16 more) → markdown
+- Known AI bot User-Agent (GPTBot, ClaudeBot, PerplexityBot, +21 more) → markdown
 - Direct `.md` URL → markdown
 - Anything else → HTML, with `Link rel="alternate"` pointing to the twin
 
@@ -238,7 +238,7 @@ Three conformance levels — **Basic** (60%), **Standard** (80%), **Advanced** (
 
 | Package | npm | Size | What it does |
 |---|---|---|---|
-| [`@dualmark/core`](./packages/core) | `npm i @dualmark/core` | 14 KB | Framework-agnostic primitives: content negotiation (RFC 7231), AI-bot detection (19 known bots), markdown response builder, token estimation, composition helpers, `llms.txt` rendering. Zero runtime deps. |
+| [`@dualmark/core`](./packages/core) | `npm i @dualmark/core` | 14 KB | Framework-agnostic primitives: content negotiation (RFC 7231), AI-bot detection (24 known bots), markdown response builder, token estimation, composition helpers, `llms.txt` rendering. Zero runtime deps. |
 | [`@dualmark/converters`](./packages/converters) | `npm i @dualmark/converters` | 16 KB | 12 production-tested converter factories. |
 | [`@dualmark/astro`](./packages/astro) | `npm i @dualmark/astro` | 22 KB | Astro 5 integration. Auto-generates `.md` endpoints, ships middleware, generates `llms.txt`. |
 | [`@dualmark/nextjs`](./packages/nextjs) | `npm i @dualmark/nextjs` | 15 KB | Next.js App Router adapter. `withDualmark()`, `createDualmarkMiddleware()`, `createDualmarkRouteHandler()`, `createLlmsTxtHandler()`. |
@@ -258,7 +258,7 @@ Plus:
 
 | Surface | Status |
 |---|---|
-| `@dualmark/core` | 167 tests pass (vitest + fast-check property tests) |
+| `@dualmark/core` | 172 tests pass (vitest + fast-check property tests) |
 | `@dualmark/converters` | 24 tests pass |
 | `@dualmark/cloudflare` | 23 tests pass |
 | `@dualmark/cli` | 17 tests pass |
@@ -272,7 +272,7 @@ Plus:
 
 ```bash
 bun install
-bun run build && bun run test && bun run typecheck   # 313 tests across 6 packages
+bun run build && bun run test && bun run typecheck   # 318 tests across 6 packages
 ```
 
 ---

--- a/apps/docs/app/_components/transform.tsx
+++ b/apps/docs/app/_components/transform.tsx
@@ -88,7 +88,7 @@ export function Transform() {
           Accept
         </code>{" "}
         header for known clients and by User-Agent for the 19 most-common AI
-        crawlers (GPTBot, ClaudeBot, PerplexityBot, +16 more).
+        crawlers (GPTBot, ClaudeBot, PerplexityBot, +21 more).
       </p>
     </Section>
   );

--- a/apps/docs/content/docs/integrations/cloudflare-workers.mdx
+++ b/apps/docs/content/docs/integrations/cloudflare-workers.mdx
@@ -96,7 +96,7 @@ bunx @dualmark/cli verify http://localhost:8787/blog/your-post
 ## What it does
 
 1. **Trailing slash enforcement** — configurable: `never` (default), `always`, `preserve`
-2. **AI bot detection** — via UA, against the registry of [19 known crawlers](/docs/spec/ai-bot-detection)
+2. **AI bot detection** — via UA, against the registry of [24 known crawlers](/docs/spec/ai-bot-detection)
 3. **Content negotiation** — via Accept header, RFC 7231 §5.3.2 compliant
 4. **Markdown serving** — pre-built `.md` from `env.ASSETS` with full AEO headers
 5. **Internal redirects** — routes to target's `.md` with `X-Redirect-From` / `X-Redirect-To`

--- a/apps/docs/content/docs/packages/core.mdx
+++ b/apps/docs/content/docs/packages/core.mdx
@@ -45,7 +45,7 @@ import { AI_BOTS, detectAIBot } from "@dualmark/core";
 
 ### `detectAIBot(userAgent: string): AIBotInfo`
 
-Returns `{ isBot, name, vendor, purpose, entry }`. The registry covers 19 known crawlers across OpenAI, Anthropic, Google, Perplexity, Common Crawl, and more — see [spec/ai-bot-detection](/docs/spec/ai-bot-detection).
+Returns `{ isBot, name, vendor, purpose, entry }`. The registry covers 24 known crawlers across OpenAI, Anthropic, Google, Perplexity, Common Crawl, and more — see [spec/ai-bot-detection](/docs/spec/ai-bot-detection).
 
 ### `AI_BOTS: AIBotEntry[]`
 

--- a/apps/docs/content/docs/packages/nextjs.mdx
+++ b/apps/docs/content/docs/packages/nextjs.mdx
@@ -60,7 +60,7 @@ _On Next.js ≤15, name the file `middleware.ts` instead. Body is identical._
 The middleware:
 
 - Rewrites `*.md` URLs to the internal `/md/<path>` namespace
-- Detects 19 known AI bot User-Agents and rewrites their requests to markdown
+- Detects 24 known AI bot User-Agents and rewrites their requests to markdown
 - Honors `Accept: text/markdown` per RFC 7231
 - Returns `406 Not Acceptable` when the request explicitly excludes both `text/html` and `text/markdown`
 - Adds `Link: <…>; rel="alternate"; type="text/markdown"` and `Vary: Accept` to HTML responses

--- a/apps/docs/content/docs/spec/ai-bot-detection.mdx
+++ b/apps/docs/content/docs/spec/ai-bot-detection.mdx
@@ -36,7 +36,7 @@ A server matching by User-Agent SHOULD use case-insensitive substring matching a
 | Omgilibot | `Omgilibot` | Webz.io | training | — |
 | DuckAssistBot | `DuckAssistBot` | DuckDuckGo | search | — |
 | Meta-ExternalAgent | `meta-externalagent` | Meta | training | — |
-| Meta-ExternalFetcher | `ExternalFetcher` | Meta | training | — |
+| Meta-ExternalFetcher | `meta-externalfetcher` | Meta | training | — |
 
 ## Purpose Categories
 

--- a/apps/docs/content/docs/spec/ai-bot-detection.mdx
+++ b/apps/docs/content/docs/spec/ai-bot-detection.mdx
@@ -36,7 +36,7 @@ A server matching by User-Agent SHOULD use case-insensitive substring matching a
 | Omgilibot | `Omgilibot` | Webz.io | training | — |
 | DuckAssistBot | `DuckAssistBot` | DuckDuckGo | search | — |
 | Meta-ExternalAgent | `meta-externalagent` | Meta | training | — |
-| Meta-ExternalFetcher | `meta-externalfetcher` | Meta | training | — |
+| Meta-ExternalFetcher | `meta-externalfetcher` | Meta | user-action | — |
 
 ## Purpose Categories
 

--- a/apps/docs/content/docs/spec/ai-bot-detection.mdx
+++ b/apps/docs/content/docs/spec/ai-bot-detection.mdx
@@ -19,12 +19,16 @@ A server matching by User-Agent SHOULD use case-insensitive substring matching a
 | ClaudeBot | `ClaudeBot` | Anthropic | training | https://support.anthropic.com/en/articles/8896518 |
 | Anthropic-ai | `Anthropic-ai` | Anthropic | training | — |
 | Claude-Web | `Claude-Web` | Anthropic | user-action | — |
+| Claude-SearchBot | `Claude-SearchBot` | Anthropic | search | https://support.anthropic.com/en/articles/8896518 |
+| Claude-User | `Claude-User` | Anthropic | user-action | https://support.anthropic.com/en/articles/8896518 |
 | PerplexityBot | `PerplexityBot` | Perplexity | search | https://docs.perplexity.ai/guides/bots |
+| Perplexity-User | `Perplexity-User` | Perplexity | user-action | https://docs.perplexity.ai/guides/bots |
 | Google-Extended | `Google-Extended` | Google | training | https://developers.google.com/search/docs/crawling-indexing/google-extended |
 | Applebot-Extended | `Applebot-Extended` | Apple | training | https://support.apple.com/en-us/119829 |
 | cohere-ai | `cohere-ai` | Cohere | training | — |
 | CCBot | `CCBot` | Common Crawl | training | https://commoncrawl.org/ccbot |
 | Bytespider | `Bytespider` | ByteDance | training | — |
+| DeepSeekBot | `DeepSeekBot` | DeepSeek | training | — |
 | Amazonbot | `Amazonbot` | Amazon | training | https://developer.amazon.com/amazonbot |
 | YouBot | `YouBot` | You.com | search | — |
 | Diffbot | `Diffbot` | Diffbot | training | — |
@@ -32,6 +36,7 @@ A server matching by User-Agent SHOULD use case-insensitive substring matching a
 | Omgilibot | `Omgilibot` | Webz.io | training | — |
 | DuckAssistBot | `DuckAssistBot` | DuckDuckGo | search | — |
 | Meta-ExternalAgent | `meta-externalagent` | Meta | training | — |
+| Meta-ExternalFetcher | `ExternalFetcher` | Meta | training | — |
 
 ## Purpose Categories
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -13,7 +13,7 @@ bun add @dualmark/core
 ## What's in it
 
 - **Content negotiation** (`parseAcceptHeader`, `negotiateFormat`) — RFC 7231 §5.3.2 compliant
-- **AI bot detection** (`detectAIBot`, `AI_BOTS`) — registry of 19 known crawlers with vendor + purpose metadata
+- **AI bot detection** (`detectAIBot`, `AI_BOTS`) — registry of 24 known crawlers with vendor + purpose metadata
 - **Markdown response** (`markdownResponse`, `injectMarkdownAlternateLink`) — builds `Response` objects with all AEO headers
 - **Path utilities** (`toMarkdownPath`, `toMarkdownUrl`) — convert HTML paths/URLs to their markdown twins
 - **Token estimation** (`estimateTokens`) — default is whitespace-split

--- a/packages/core/src/bots.ts
+++ b/packages/core/src/bots.ts
@@ -168,7 +168,7 @@ export const AI_BOTS: ReadonlyArray<AIBotEntry> = [
   },
   {
     name: "Meta-ExternalFetcher",
-    uaPattern: "ExternalFetcher",
+    uaPattern: "meta-externalfetcher",
     vendor: "Meta",
     purpose: "training",
   },

--- a/packages/core/src/bots.ts
+++ b/packages/core/src/bots.ts
@@ -170,7 +170,7 @@ export const AI_BOTS: ReadonlyArray<AIBotEntry> = [
     name: "Meta-ExternalFetcher",
     uaPattern: "meta-externalfetcher",
     vendor: "Meta",
-    purpose: "training",
+    purpose: "user-action",
   },
 ];
 

--- a/packages/core/src/bots.ts
+++ b/packages/core/src/bots.ts
@@ -57,10 +57,31 @@ export const AI_BOTS: ReadonlyArray<AIBotEntry> = [
     purpose: "user-action",
   },
   {
+    name: "Claude-SearchBot",
+    uaPattern: "Claude-SearchBot",
+    vendor: "Anthropic",
+    purpose: "search",
+    docsUrl: "https://support.anthropic.com/en/articles/8896518",
+  },
+  {
+    name: "Claude-User",
+    uaPattern: "Claude-User",
+    vendor: "Anthropic",
+    purpose: "user-action",
+    docsUrl: "https://support.anthropic.com/en/articles/8896518",
+  },
+  {
     name: "PerplexityBot",
     uaPattern: "PerplexityBot",
     vendor: "Perplexity",
     purpose: "search",
+    docsUrl: "https://docs.perplexity.ai/guides/bots",
+  },
+  {
+    name: "Perplexity-User",
+    uaPattern: "Perplexity-User",
+    vendor: "Perplexity",
+    purpose: "user-action",
     docsUrl: "https://docs.perplexity.ai/guides/bots",
   },
   {
@@ -94,6 +115,12 @@ export const AI_BOTS: ReadonlyArray<AIBotEntry> = [
     name: "Bytespider",
     uaPattern: "Bytespider",
     vendor: "ByteDance",
+    purpose: "training",
+  },
+  {
+    name: "DeepSeekBot",
+    uaPattern: "DeepSeekBot",
+    vendor: "DeepSeek",
     purpose: "training",
   },
   {
@@ -136,6 +163,12 @@ export const AI_BOTS: ReadonlyArray<AIBotEntry> = [
   {
     name: "Meta-ExternalAgent",
     uaPattern: "meta-externalagent",
+    vendor: "Meta",
+    purpose: "training",
+  },
+  {
+    name: "Meta-ExternalFetcher",
+    uaPattern: "ExternalFetcher",
     vendor: "Meta",
     purpose: "training",
   },

--- a/packages/core/test/bots.test.ts
+++ b/packages/core/test/bots.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { detectAIBot, AI_BOTS } from "../src/bots.js";
 
+function uaPatternOk(pattern: string, name: string, vendor: string): boolean {
+  if (pattern.includes("-")) return true; // hyphen: namespaced id
+  const p = pattern.toLowerCase();
+  if (vendor.toLowerCase().split(/[^a-z0-9]+/).some((t) => t.length >= 3 && p.includes(t))) return true; // vendor substring (≥3 alnum)
+  const c = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return c(pattern) === c(name); // same identity as bot name
+}
+
 describe("detectAIBot", () => {
   it("returns isBot=false for empty UA", () => {
     expect(detectAIBot("")).toEqual({ isBot: false, name: null, vendor: null, purpose: null });
@@ -58,12 +66,27 @@ describe("detectAIBot", () => {
     expect(r).toMatchObject({ isBot: true, name: "Claude-User", vendor: "Anthropic" });
   });
 
-  it("detects Meta-ExternalFetcher", () => {
+  it("detects Meta-ExternalFetcher (vendor-namespaced token, case-insensitive)", () => {
     expect(detectAIBot("Mozilla/5.0 (compatible; Meta-ExternalFetcher/1.0)").name).toBe("Meta-ExternalFetcher");
+    expect(detectAIBot("meta-externalfetcher/1.0").name).toBe("Meta-ExternalFetcher");
+  });
+
+  it("does not falsely match generic ExternalFetcher UAs", () => {
+    expect(detectAIBot("Mozilla/5.0 SomeBrand-ExternalFetcher/2.0").isBot).toBe(false);
+    expect(detectAIBot("Mozilla/5.0 (compatible; MyExternalFetcher/1.0)").isBot).toBe(false);
+    expect(detectAIBot("Bot ExternalFetcher v3").isBot).toBe(false);
   });
 
   it("detects Perplexity-User", () => {
     expect(detectAIBot("Mozilla/5.0 (compatible; Perplexity-User/1.0)").name).toBe("Perplexity-User");
+  });
+
+  it("AI_BOTS uaPattern invariant: hyphen, vendor token (≥3), or collapsed name", () => {
+    for (const b of AI_BOTS) {
+      if (typeof b.uaPattern !== "string") continue;
+      expect(uaPatternOk(b.uaPattern, b.name, b.vendor), `${b.name}: ${JSON.stringify(b.uaPattern)}`).toBe(true);
+    }
+    expect(uaPatternOk("ExternalFetcher", "Meta-ExternalFetcher", "Meta")).toBe(false);
   });
 
   it("AI_BOTS export has unique names", () => {

--- a/packages/core/test/bots.test.ts
+++ b/packages/core/test/bots.test.ts
@@ -43,6 +43,29 @@ describe("detectAIBot", () => {
     expect(detectAIBot("meta-externalagent/1.0").vendor).toBe("Meta");
   });
 
+  it("detects DeepSeekBot", () => {
+    const r = detectAIBot("Mozilla/5.0 (compatible; DeepSeekBot/1.0; +https://www.deepseek.com/bot)");
+    expect(r).toMatchObject({ isBot: true, name: "DeepSeekBot", vendor: "DeepSeek", purpose: "training" });
+  });
+
+  it("detects Claude-SearchBot", () => {
+    const r = detectAIBot("Mozilla/5.0 (compatible; Claude-SearchBot/1.0; searchbot@anthropic.com)");
+    expect(r).toMatchObject({ isBot: true, name: "Claude-SearchBot", vendor: "Anthropic" });
+  });
+
+  it("detects Claude-User", () => {
+    const r = detectAIBot("Mozilla/5.0 (compatible; Claude-User/1.0)");
+    expect(r).toMatchObject({ isBot: true, name: "Claude-User", vendor: "Anthropic" });
+  });
+
+  it("detects Meta-ExternalFetcher", () => {
+    expect(detectAIBot("Mozilla/5.0 (compatible; Meta-ExternalFetcher/1.0)").name).toBe("Meta-ExternalFetcher");
+  });
+
+  it("detects Perplexity-User", () => {
+    expect(detectAIBot("Mozilla/5.0 (compatible; Perplexity-User/1.0)").name).toBe("Perplexity-User");
+  });
+
   it("AI_BOTS export has unique names", () => {
     const names = AI_BOTS.map((b) => b.name);
     expect(new Set(names).size).toBe(names.length);

--- a/spec/ai-bot-detection.md
+++ b/spec/ai-bot-detection.md
@@ -33,7 +33,7 @@ A server matching by User-Agent SHOULD use case-insensitive substring matching a
 | Omgilibot | `Omgilibot` | Webz.io | training | — |
 | DuckAssistBot | `DuckAssistBot` | DuckDuckGo | search | — |
 | Meta-ExternalAgent | `meta-externalagent` | Meta | training | — |
-| Meta-ExternalFetcher | `ExternalFetcher` | Meta | training | — |
+| Meta-ExternalFetcher | `meta-externalfetcher` | Meta | training | — |
 
 ## Purpose Categories
 

--- a/spec/ai-bot-detection.md
+++ b/spec/ai-bot-detection.md
@@ -16,12 +16,16 @@ A server matching by User-Agent SHOULD use case-insensitive substring matching a
 | ClaudeBot | `ClaudeBot` | Anthropic | training | https://support.anthropic.com/en/articles/8896518 |
 | Anthropic-ai | `Anthropic-ai` | Anthropic | training | — |
 | Claude-Web | `Claude-Web` | Anthropic | user-action | — |
+| Claude-SearchBot | `Claude-SearchBot` | Anthropic | search | https://support.anthropic.com/en/articles/8896518 |
+| Claude-User | `Claude-User` | Anthropic | user-action | https://support.anthropic.com/en/articles/8896518 |
 | PerplexityBot | `PerplexityBot` | Perplexity | search | https://docs.perplexity.ai/guides/bots |
+| Perplexity-User | `Perplexity-User` | Perplexity | user-action | https://docs.perplexity.ai/guides/bots |
 | Google-Extended | `Google-Extended` | Google | training | https://developers.google.com/search/docs/crawling-indexing/google-extended |
 | Applebot-Extended | `Applebot-Extended` | Apple | training | https://support.apple.com/en-us/119829 |
 | cohere-ai | `cohere-ai` | Cohere | training | — |
 | CCBot | `CCBot` | Common Crawl | training | https://commoncrawl.org/ccbot |
 | Bytespider | `Bytespider` | ByteDance | training | — |
+| DeepSeekBot | `DeepSeekBot` | DeepSeek | training | — |
 | Amazonbot | `Amazonbot` | Amazon | training | https://developer.amazon.com/amazonbot |
 | YouBot | `YouBot` | You.com | search | — |
 | Diffbot | `Diffbot` | Diffbot | training | — |
@@ -29,6 +33,7 @@ A server matching by User-Agent SHOULD use case-insensitive substring matching a
 | Omgilibot | `Omgilibot` | Webz.io | training | — |
 | DuckAssistBot | `DuckAssistBot` | DuckDuckGo | search | — |
 | Meta-ExternalAgent | `meta-externalagent` | Meta | training | — |
+| Meta-ExternalFetcher | `ExternalFetcher` | Meta | training | — |
 
 ## Purpose Categories
 

--- a/spec/ai-bot-detection.md
+++ b/spec/ai-bot-detection.md
@@ -33,7 +33,7 @@ A server matching by User-Agent SHOULD use case-insensitive substring matching a
 | Omgilibot | `Omgilibot` | Webz.io | training | — |
 | DuckAssistBot | `DuckAssistBot` | DuckDuckGo | search | — |
 | Meta-ExternalAgent | `meta-externalagent` | Meta | training | — |
-| Meta-ExternalFetcher | `meta-externalfetcher` | Meta | training | — |
+| Meta-ExternalFetcher | `meta-externalfetcher` | Meta | user-action | — |
 
 ## Purpose Categories
 


### PR DESCRIPTION
## Summary

Extends the `@dualmark/core` AI bot registry with five new crawlers and keeps the spec registry table (and synced docs) aligned. Closes #15.

## Changes

<!-- bullets, focused on what + why -->

 - Add `DeepSeekBot`, `Claude-SearchBot`, `Claude-User`, `Meta-ExternalFetcher`, and `Perplexity-User` to `AI_BOTS` so negotiation can treat them like other listed bots.
  - Add matching tests in `packages/core/test/bots.test.ts` (same patterns as existing bot tests).
  - Update `spec/ai-bot-detection.md` and run `bun run --filter dualmark-docs sync-spec` for the docs mirror; refresh stale bot/test counts in README and a few docs lines.

## Type

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change
- [ ] Spec change (requires bump in `AEO_SPEC_VERSION`)
- [ ] Docs / examples / tooling only

## Verification

- [x] `bun run build` passes
- [x] `bun run test` passes
- [x] `bun run typecheck` passes
- [x] If touching examples: ran `dualmark verify` against the example end-to-end
- [x] If touching `/spec/`: ran `bun run --filter dualmark-docs sync-spec` and committed the mirror

## Changeset

- [x] Added a changeset (`bun run changeset`) for any package with a user-visible change
