### PR TITLE
docs: add Use in CI guide (#20)

### DIFF
--- a/apps/docs/content/docs/ci.mdx
+++ b/apps/docs/content/docs/ci.mdx
@@ -37,23 +37,6 @@ directly (e.g. `https://staging.example.com/blog/your-post`).
 
 <Step>
 
-## Set a minimum score threshold
-
-Pass `--min-score` to fail the build below a specific score instead of relying only on required
-checks:
-
-```yaml title=".github/workflows/aeo.yml"
-- name: Verify AEO conformance
-  run: bunx @dualmark/cli verify https://staging.example.com/blog/your-post --min-score 95
-```
-
-See [Scoring & levels](/docs/conformance/scoring) for what score maps to Basic / Standard /
-Advanced conformance.
-
-</Step>
-
-<Step>
-
 ## Parse results in downstream steps
 
 Use `--json` to get a machine-readable report you can forward to a dashboard or annotation step:
@@ -70,8 +53,8 @@ Use `--json` to get a machine-readable report you can forward to a dashboard or 
 ```
 
 <Callout type="info">
-  `--json` is mutually exclusive with colored output. Exit codes remain the same — non-zero on
-  required-check failure.
+  Exit codes are the same with `--json` — non-zero on required-check failure. The JSON report can
+  be consumed by dashboards, Slack bots, or custom annotation scripts.
 </Callout>
 
 </Step>

--- a/apps/docs/content/docs/ci.mdx
+++ b/apps/docs/content/docs/ci.mdx
@@ -53,8 +53,8 @@ Use `--json` to get a machine-readable report you can forward to a dashboard or 
 ```
 
 <Callout type="info">
-  Exit codes are the same with `--json` — non-zero on required-check failure. The JSON report can
-  be consumed by dashboards, Slack bots, or custom annotation scripts.
+  Exit codes are the same with `--json` — non-zero on required-check failure. The JSON report can be
+  consumed by dashboards, Slack bots, or custom annotation scripts.
 </Callout>
 
 </Step>

--- a/apps/docs/content/docs/ci.mdx
+++ b/apps/docs/content/docs/ci.mdx
@@ -1,0 +1,139 @@
+---
+title: Use in CI
+description: Run dualmark verify in your pipeline to catch AEO regressions before they ship.
+---
+
+`dualmark verify` exits non-zero when a required check fails, making it a natural fit for any CI
+pipeline. Add it to your pull-request workflow and block merges the moment conformance drops.
+
+## GitHub Actions
+
+<Steps>
+
+<Step>
+
+## Add the workflow file
+
+```yaml title=".github/workflows/aeo.yml"
+name: AEO Conformance
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  aeo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify AEO conformance
+        run: bunx @dualmark/cli verify ${{ vars.STAGING_URL }} --timeout 15000
+```
+
+Replace `vars.STAGING_URL` with the URL of your staging deployment, or hard-code a page URL
+directly (e.g. `https://staging.example.com/blog/your-post`).
+
+</Step>
+
+<Step>
+
+## Set a minimum score threshold
+
+Pass `--min-score` to fail the build below a specific score instead of relying only on required
+checks:
+
+```yaml title=".github/workflows/aeo.yml"
+- name: Verify AEO conformance
+  run: bunx @dualmark/cli verify https://staging.example.com/blog/your-post --min-score 95
+```
+
+See [Scoring & levels](/docs/conformance/scoring) for what score maps to Basic / Standard /
+Advanced conformance.
+
+</Step>
+
+<Step>
+
+## Parse results in downstream steps
+
+Use `--json` to get a machine-readable report you can forward to a dashboard or annotation step:
+
+```yaml title=".github/workflows/aeo.yml"
+- name: Verify AEO conformance
+  run: bunx @dualmark/cli verify https://staging.example.com/blog/your-post --json > aeo.json
+
+- name: Upload report
+  uses: actions/upload-artifact@v4
+  with:
+    name: aeo-report
+    path: aeo.json
+```
+
+<Callout type="info">
+  `--json` is mutually exclusive with colored output. Exit codes remain the same — non-zero on
+  required-check failure.
+</Callout>
+
+</Step>
+
+</Steps>
+
+## GitLab CI
+
+```yaml title=".gitlab-ci.yml"
+aeo-conformance:
+  image: oven/bun:latest
+  script:
+    - bunx @dualmark/cli verify https://staging.example.com/blog/your-post --timeout 15000
+  only:
+    - merge_requests
+    - main
+```
+
+For JSON output in GitLab, pipe to a file and expose it as an artifact:
+
+```yaml title=".gitlab-ci.yml"
+aeo-conformance:
+  image: oven/bun:latest
+  script:
+    - bunx @dualmark/cli verify https://staging.example.com/blog/your-post --json > aeo.json
+  artifacts:
+    paths:
+      - aeo.json
+    when: always
+```
+
+## Docker / self-hosted runners
+
+If your runner has Docker available but not Bun, use the official Bun image directly:
+
+```bash
+docker run --rm oven/bun:latest \
+  bunx @dualmark/cli verify https://example.com/blog/your-post
+```
+
+Or in a `docker-compose`-based pipeline:
+
+```yaml
+services:
+  aeo:
+    image: oven/bun:latest
+    command: bunx @dualmark/cli verify https://example.com/blog/your-post
+```
+
+## GitHub Action (coming soon)
+
+A first-class `dodopayments/dualmark-action` is on the roadmap — it will let you drop AEO
+conformance into any workflow with a single `uses:` line and no Bun setup required. Track progress
+in [issue #17](https://github.com/dodopayments/dualmark/issues/17).
+
+## Next steps
+
+<Cards>
+  <Card title="The verify CLI" href="/docs/conformance/cli">
+    Full flag reference, exit codes, and programmatic API.
+  </Card>
+  <Card title="Scoring & levels" href="/docs/conformance/scoring">
+    What each check is worth. Basic / Standard / Advanced thresholds explained.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/ci.mdx
+++ b/apps/docs/content/docs/ci.mdx
@@ -26,6 +26,10 @@ jobs:
   aeo:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
       - name: Verify AEO conformance
         run: bunx @dualmark/cli verify ${{ vars.STAGING_URL }} --timeout 15000
 ```

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -4,6 +4,8 @@
     "---[Rocket]Get started---",
     "quickstart",
     "concepts",
+    "---[CirclePlay]CI & automation---",
+    "ci",
     "---[Plug]Integrate---",
     "...integrations",
     "---[Package]API reference---",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -68,6 +68,8 @@ Notes:
 - `1` — fail (below threshold or any required check failed)
 - `2` — CLI usage error
 
+For GitHub Actions, GitLab CI, and Docker examples, see the [Use in CI guide](https://dualmark.dev/docs/ci).
+
 ## Programmatic usage
 
 ```ts


### PR DESCRIPTION
## Summary
Adds a "Use in CI" guide to the docs covering how to run `dualmark verify` in GitHub Actions, GitLab CI, and Docker pipelines.

## Changes
- Added `apps/docs/content/docs/ci.mdx` with GitHub Actions, GitLab CI, and Docker examples
- Includes `--json` and `--timeout` flag usage in CI context
- Links to upcoming `dodopayments/dualmark-action` (#17) as "coming soon"
- Added "CI & automation" section to left nav in `apps/docs/content/docs/meta.json`
- Added cross-link to the guide in `packages/cli/README.md`

## Type
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Spec change (requires bump in `AEO_SPEC_VERSION`)
- [x] Docs / examples / tooling only

## Verification
- [x] `bun run build` passes
- [x] `bun run test` passes
- [x] `bun run typecheck` passes
- [ ] If touching examples: ran `dualmark verify` against the example end-to-end
- [ ] If touching `/spec/`: ran `bun run --filter dualmark-docs sync-spec` and committed the mirror

## Changeset
- [ ] Added a changeset (`bun run changeset`) for any package with a user-visible change