### PR TITLE
feat(converters): add integrationConverter for marketplace integration pages

### DIFF
--- a/.changeset/add-integration-converter.md
+++ b/.changeset/add-integration-converter.md
@@ -1,0 +1,5 @@
+---
+"@dualmark/converters": minor
+---
+
+Add `integrationConverter` for marketplace-style integration pages (vendor, categories, capabilities, optional setup, pricing, requirements). Register as built-in `integration` in Astro and Next.js resolvers.

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ You already invested in SEO. Now invest in AEO — for **a fraction of the effor
 | **`llms.txt` proposal keeps changing** | Hand-maintained, drifts from sitemap | Auto-generated from the same config that drives your routes |
 | **Every team rebuilds this** | Custom middleware in every repo, none of them quite right | One battle-tested package, conforms to a public spec |
 | **No analytics for AI traffic** | "Was that a bot or a human?" | `onAIRequest` hook + Cloudflare Analytics Engine integration: bot name, vendor, page, tokens, country |
-| **Slow to roll out across pages** | Marketing waits weeks for engineering | Add `converter: "compare"` to a collection — done. 12 converters bundled. |
+| **Slow to roll out across pages** | Marketing waits weeks for engineering | Add `converter: "compare"` to a collection — done. 13 converters bundled. |
 
 **Built and battle-tested at [Dodo Payments](https://dodopayments.com)** for our own marketing site. Now extracted as OSS so you don't have to write the same content negotiation, bot detection, and edge wrapping over and over.
 
@@ -166,7 +166,7 @@ No duplicate content penalties (markdown twin sets `X-Robots-Tag: noindex`). No 
 
 ## Built-in converters (`@dualmark/converters`)
 
-Drop-in markdown generation for the 12 page types every marketing site has:
+Drop-in markdown generation for the 13 page types every marketing site has:
 
 | Converter | What it's for | Marketing examples |
 |---|---|---|
@@ -177,6 +177,7 @@ Drop-in markdown generation for the 12 page types every marketing site has:
 | `docs` | Documentation | Getting started, API guides |
 | `feature` | Product/feature pages | "Webhooks", "SSO" — problem/solution + FAQ |
 | `glossary` | Term definitions | "What is a payment gateway?" |
+| `integration` | App marketplace / integrations | "Connect Stripe to Acme", Slack connector pages |
 | `legal` | Policy pages | Terms, Privacy, DPA |
 | `pricing` | Pricing tables | Tier comparison with CTAs |
 | `pseo` | Programmatic SEO | "SEO services in San Francisco" with facts + cross-links |
@@ -239,7 +240,7 @@ Three conformance levels — **Basic** (60%), **Standard** (80%), **Advanced** (
 | Package | npm | Size | What it does |
 |---|---|---|---|
 | [`@dualmark/core`](./packages/core) | `npm i @dualmark/core` | 14 KB | Framework-agnostic primitives: content negotiation (RFC 7231), AI-bot detection (24 known bots), markdown response builder, token estimation, composition helpers, `llms.txt` rendering. Zero runtime deps. |
-| [`@dualmark/converters`](./packages/converters) | `npm i @dualmark/converters` | 16 KB | 12 production-tested converter factories. |
+| [`@dualmark/converters`](./packages/converters) | `npm i @dualmark/converters` | 16 KB | 13 production-tested converter factories. |
 | [`@dualmark/astro`](./packages/astro) | `npm i @dualmark/astro` | 22 KB | Astro 5 integration. Auto-generates `.md` endpoints, ships middleware, generates `llms.txt`. |
 | [`@dualmark/nextjs`](./packages/nextjs) | `npm i @dualmark/nextjs` | 15 KB | Next.js App Router adapter. `withDualmark()`, `createDualmarkMiddleware()`, `createDualmarkRouteHandler()`, `createLlmsTxtHandler()`. |
 | [`@dualmark/cloudflare`](./packages/cloudflare) | `npm i @dualmark/cloudflare` | 9 KB | Workers edge adapter. Wraps any upstream Worker. Hooks for analytics + telemetry. |
@@ -259,7 +260,7 @@ Plus:
 | Surface | Status |
 |---|---|
 | `@dualmark/core` | 174 tests pass (vitest + fast-check property tests) |
-| `@dualmark/converters` | 24 tests pass |
+| `@dualmark/converters` | 27 tests pass |
 | `@dualmark/cloudflare` | 23 tests pass |
 | `@dualmark/cli` | 17 tests pass |
 | `@dualmark/astro` | 35 tests pass |
@@ -272,7 +273,7 @@ Plus:
 
 ```bash
 bun install
-bun run build && bun run test && bun run typecheck   # 320 tests across 6 packages
+bun run build && bun run test && bun run typecheck   # 323 tests across 6 packages
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Plus:
 | Surface | Status |
 |---|---|
 | `@dualmark/core` | 174 tests pass (vitest + fast-check property tests) |
-| `@dualmark/converters` | 27 tests pass |
+| `@dualmark/converters` | 28 tests pass |
 | `@dualmark/cloudflare` | 23 tests pass |
 | `@dualmark/cli` | 17 tests pass |
 | `@dualmark/astro` | 35 tests pass |
@@ -273,7 +273,7 @@ Plus:
 
 ```bash
 bun install
-bun run build && bun run test && bun run typecheck   # 323 tests across 6 packages
+bun run build && bun run test && bun run typecheck   # 324 tests across 6 packages
 ```
 
 ---

--- a/apps/docs/app/raw/index.md/route.ts
+++ b/apps/docs/app/raw/index.md/route.ts
@@ -24,7 +24,7 @@ See https://dualmark.dev/docs/quickstart for the full integration guide.
 - \`@dualmark/astro\` — Astro 5 integration
 - \`@dualmark/cloudflare\` — Workers edge adapter
 - \`@dualmark/cli\` — \`dualmark verify\` conformance test runner
-- \`@dualmark/converters\` — 12 production-tested page-type converters
+- \`@dualmark/converters\` — 13 production-tested page-type converters
 
 ## Links
 

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -57,7 +57,7 @@ Built and battle-tested at [Dodo Payments](https://dodopayments.com).
 
 <Cards>
   <Card icon={<Box />} title="@dualmark/core" href="/docs/packages/core" description="Framework-agnostic primitives — content negotiation, AI-bot detection, markdown responses." />
-  <Card icon={<ArrowLeftRight />} title="@dualmark/converters" href="/docs/packages/converters" description="12 production-tested page-type converters — blog, glossary, pricing, changelog, and more." />
+  <Card icon={<ArrowLeftRight />} title="@dualmark/converters" href="/docs/packages/converters" description="13 production-tested page-type converters — blog, glossary, integration, pricing, changelog, and more." />
   <Card icon={<AstroLogo />} title="@dualmark/astro" href="/docs/packages/astro" description="Astro 5 integration with auto-generated routes and llms.txt." />
   <Card icon={<NextLogo />} title="@dualmark/nextjs" href="/docs/packages/nextjs" description="Next.js 15 App Router adapter — withDualmark, middleware factory, route handler factory." />
   <Card icon={<CloudflareLogo />} title="@dualmark/cloudflare" href="/docs/packages/cloudflare" description="Workers edge adapter with hooks for analytics and transformations." />

--- a/apps/docs/content/docs/integrations/astro.mdx
+++ b/apps/docs/content/docs/integrations/astro.mdx
@@ -108,7 +108,7 @@ dualmark({
 
 ## Available converters
 
-`converter: "blog" | "case-study" | "changelog" | "compare" | "docs" | "feature" | "glossary" | "legal" | "pricing" | "pseo" | "tool" | "video"` — see [@dualmark/converters](/docs/packages/converters).
+`converter: "blog" | "case-study" | "changelog" | "compare" | "docs" | "feature" | "glossary" | "integration" | "legal" | "pricing" | "pseo" | "tool" | "video"` — see [@dualmark/converters](/docs/packages/converters).
 
 You can also pass a custom function: `converter: (entry) => string`.
 

--- a/apps/docs/content/docs/integrations/nextjs.mdx
+++ b/apps/docs/content/docs/integrations/nextjs.mdx
@@ -158,7 +158,7 @@ export const GET = handler.GET;
 
 ## Built-in converter names
 
-`blog`, `case-study`, `changelog`, `compare`, `docs`, `feature`, `glossary`, `legal`, `pricing`, `pseo`, `tool`, `video` — see [@dualmark/converters](/docs/packages/converters). Or pass a custom function `(entry) => string`.
+`blog`, `case-study`, `changelog`, `compare`, `docs`, `feature`, `glossary`, `integration`, `legal`, `pricing`, `pseo`, `tool`, `video` — see [@dualmark/converters](/docs/packages/converters). Or pass a custom function `(entry) => string`.
 
 ## Verify
 

--- a/apps/docs/content/docs/packages/astro.mdx
+++ b/apps/docs/content/docs/packages/astro.mdx
@@ -66,7 +66,7 @@ interface DualmarkAstroConfig {
 collections: {
   blog: {
     converter: "blog" | "case-study" | "changelog" | "compare" | "docs"
-              | "feature" | "glossary" | "legal" | "pricing" | "pseo"
+              | "feature" | "glossary" | "integration" | "legal" | "pricing" | "pseo"
               | "tool" | "video"
               | ((entry) => string),  // or custom function
 

--- a/apps/docs/content/docs/packages/converters.mdx
+++ b/apps/docs/content/docs/packages/converters.mdx
@@ -1,6 +1,6 @@
 ---
 title: "@dualmark/converters"
-description: 12 production-tested markdown converter factories.
+description: 13 production-tested markdown converter factories.
 ---
 
 <Tabs items={["bun", "npm", "yarn"]}>
@@ -34,6 +34,7 @@ Each factory takes a config object and returns `(entry: CollectionEntry<Data>) =
 | `docsConverter` | Documentation pages |
 | `featureConverter` | Feature/product pages with siblings, FAQ, problem/solution |
 | `glossaryConverter` | Glossary terms (with learn-more + canonical-blog) |
+| `integrationConverter` | Marketplace / app integration listings (vendor, categories, capabilities) |
 | `legalConverter` | Legal pages |
 | `pricingConverter` | Pricing tables with tier highlights and CTAs |
 | `pseoConverter` | Programmatic SEO pages with facts + related-link groups |

--- a/apps/docs/content/docs/packages/nextjs.mdx
+++ b/apps/docs/content/docs/packages/nextjs.mdx
@@ -169,7 +169,7 @@ collections: {
   blog: {
     converter:
       | "blog" | "case-study" | "changelog" | "compare" | "docs"
-      | "feature" | "glossary" | "legal" | "pricing" | "pseo"
+      | "feature" | "glossary" | "integration" | "legal" | "pricing" | "pseo"
       | "tool" | "video"
       | ((entry) => string),
 

--- a/packages/astro/src/converter-registry.ts
+++ b/packages/astro/src/converter-registry.ts
@@ -6,6 +6,7 @@ import {
   docsConverter,
   featureConverter,
   glossaryConverter,
+  integrationConverter,
   legalConverter,
   pricingConverter,
   pseoConverter,
@@ -24,6 +25,7 @@ export type BuiltInConverterName =
   | "docs"
   | "feature"
   | "glossary"
+  | "integration"
   | "legal"
   | "pricing"
   | "pseo"
@@ -56,6 +58,8 @@ export function resolveBuiltInConverter(
       return featureConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "glossary":
       return glossaryConverter(cfg) as Converter<CollectionEntry<unknown>>;
+    case "integration":
+      return integrationConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "legal":
       return legalConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "pricing":
@@ -68,7 +72,7 @@ export function resolveBuiltInConverter(
       return videoConverter(cfg) as Converter<CollectionEntry<unknown>>;
     default:
       throw new Error(
-        `Dualmark: unknown built-in converter '${args.name}'. Valid names: blog, case-study, changelog, compare, docs, feature, glossary, legal, pricing, pseo, tool, video. Or pass a function.`,
+        `Dualmark: unknown built-in converter '${args.name}'. Valid names: blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, tool, video. Or pass a function.`,
       );
   }
 }

--- a/packages/converters/README.md
+++ b/packages/converters/README.md
@@ -19,6 +19,7 @@ bun add @dualmark/converters @dualmark/core
 | `docsConverter` | Documentation pages |
 | `featureConverter` | Feature/product pages with siblings, FAQ, problem/solution |
 | `glossaryConverter` | Glossary terms (with learn-more + canonical-blog) |
+| `integrationConverter` | Marketplace / app integration listings (vendor, categories, capabilities) |
 | `legalConverter` | Legal pages |
 | `pricingConverter` | Pricing tables with tier highlights and CTAs |
 | `pseoConverter` | Programmatic SEO pages with facts + related-link groups |

--- a/packages/converters/package.json
+++ b/packages/converters/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dualmark/converters",
   "version": "0.5.2",
-  "description": "12 production-tested markdown converter factories (blog, case-study, changelog, compare, docs, feature, glossary, legal, pricing, pseo, tool, video) for the Dualmark AEO framework.",
+  "description": "13 production-tested markdown converter factories (blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, tool, video) for the Dualmark AEO framework.",
   "license": "Apache-2.0",
   "author": "Dodo Payments <opensource@dodopayments.com> (https://dodopayments.com)",
   "repository": {

--- a/packages/converters/src/index.ts
+++ b/packages/converters/src/index.ts
@@ -9,6 +9,11 @@ export {
   type GlossaryConverterConfig,
   type GlossaryEntryData,
 } from "./glossary.js";
+export {
+  integrationConverter,
+  type IntegrationConverterConfig,
+  type IntegrationEntryData,
+} from "./integration.js";
 export { legalConverter, type LegalConverterConfig, type LegalEntryData } from "./legal.js";
 export {
   compareConverter,
@@ -62,6 +67,7 @@ export const BUILT_IN_CONVERTERS = [
   "docs",
   "feature",
   "glossary",
+  "integration",
   "legal",
   "pricing",
   "pseo",

--- a/packages/converters/src/integration.ts
+++ b/packages/converters/src/integration.ts
@@ -1,0 +1,76 @@
+import { cleanBody, normalizeUnicode } from "@dualmark/core";
+import type { BaseConverterConfig, CollectionEntry, Converter } from "./types.js";
+
+export interface IntegrationConverterConfig extends BaseConverterConfig {
+  basePath: string;
+}
+
+export interface IntegrationEntryData {
+  title: string;
+  vendor: string;
+  category: string[];
+  description: string;
+  capabilities: string[];
+  setupSteps?: string[];
+  pricing?: string;
+  requirements?: string[];
+}
+
+function resolveIntegrationHeading(
+  entry: CollectionEntry<IntegrationEntryData>,
+  data: IntegrationEntryData,
+): string {
+  const fromTitle = typeof data.title === "string" ? data.title.trim() : "";
+  if (fromTitle !== "") return fromTitle;
+
+  const fromVendor = typeof data.vendor === "string" ? data.vendor.trim() : "";
+  if (fromVendor !== "") return fromVendor;
+
+  return entry.id;
+}
+
+export function integrationConverter(
+  config: IntegrationConverterConfig,
+): Converter<CollectionEntry<IntegrationEntryData>> {
+  const { basePath, siteUrl, brandFooter } = config;
+  return (entry) => {
+    const d = entry.data;
+    const parts: string[] = [`# ${resolveIntegrationHeading(entry, d)}`];
+
+    parts.push(`\n- **URL**: ${siteUrl}${basePath}/${entry.id}`);
+    parts.push(`- **Vendor**: ${d.vendor}`);
+    if (d.category.length > 0) {
+      parts.push(`- **Categories**: ${d.category.join(", ")}`);
+    }
+
+    if (d.description) {
+      parts.push(`\n> ${d.description}`);
+    }
+
+    if (d.capabilities.length > 0) {
+      parts.push(`\n## Capabilities\n\n${d.capabilities.map((c) => `- ${c}`).join("\n")}`);
+    }
+
+    if (d.setupSteps && d.setupSteps.length > 0) {
+      parts.push(`\n## Setup\n\n${d.setupSteps.map((s, i) => `${i + 1}. ${s}`).join("\n")}`);
+    }
+
+    if (d.pricing) {
+      parts.push(`\n## Pricing\n\n${d.pricing}`);
+    }
+
+    if (d.requirements && d.requirements.length > 0) {
+      parts.push(`\n## Requirements\n\n${d.requirements.map((r) => `- ${r}`).join("\n")}`);
+    }
+
+    if (entry.body) {
+      parts.push(`\n---\n\n${cleanBody(entry.body)}`);
+    }
+
+    if (brandFooter) {
+      parts.push(`\n---\n${brandFooter}`);
+    }
+
+    return normalizeUnicode(parts.join("\n"));
+  };
+}

--- a/packages/converters/src/integration.ts
+++ b/packages/converters/src/integration.ts
@@ -8,7 +8,7 @@ export interface IntegrationConverterConfig extends BaseConverterConfig {
 export interface IntegrationEntryData {
   title: string;
   vendor: string;
-  category: string[];
+  categories: string[];
   description: string;
   capabilities: string[];
   setupSteps?: string[];
@@ -39,8 +39,8 @@ export function integrationConverter(
 
     parts.push(`\n- **URL**: ${siteUrl}${basePath}/${entry.id}`);
     parts.push(`- **Vendor**: ${d.vendor}`);
-    if (d.category.length > 0) {
-      parts.push(`- **Categories**: ${d.category.join(", ")}`);
+    if (d.categories.length > 0) {
+      parts.push(`- **Categories**: ${d.categories.join(", ")}`);
     }
 
     if (d.description) {

--- a/packages/converters/test/converters.test.ts
+++ b/packages/converters/test/converters.test.ts
@@ -7,6 +7,8 @@ import {
   docsConverter,
   featureConverter,
   glossaryConverter,
+  integrationConverter,
+  type IntegrationEntryData,
   legalConverter,
   pricingConverter,
   pseoConverter,
@@ -144,6 +146,106 @@ describe("glossaryConverter", () => {
       },
     });
     expect(out).toContain("[External](https://example.com/x)");
+  });
+});
+
+describe("integrationConverter", () => {
+  const convert = integrationConverter({ siteUrl: SITE, basePath: "/integrations" });
+
+  it("renders capabilities prominently with setup, pricing, and requirements", () => {
+    const out = convert({
+      id: "stripe",
+      data: {
+        title: "Connect Stripe to Acme",
+        vendor: "Stripe",
+        category: ["Payments", "Finance"],
+        description: "Accept cards and subscriptions inside Acme.",
+        capabilities: [
+          "PCI-aware checkout hosted by Stripe",
+          "Webhooks for payment lifecycle events",
+          "Customer portal for self-serve billing",
+        ],
+        setupSteps: ["Create a Stripe account", "Paste API keys in Acme", "Enable the integration"],
+        pricing: "Stripe processing fees apply; Acme does not add a platform fee for this connector.",
+        requirements: ["Acme Business plan", "Verified business profile"],
+      },
+      body: "See the [Stripe docs](https://stripe.com/docs) for API details.",
+    });
+    expect(out).toContain("# Connect Stripe to Acme");
+    expect(out).toContain("- **Vendor**: Stripe");
+    expect(out).toContain("- **Categories**: Payments, Finance");
+    expect(out).toContain("> Accept cards and subscriptions inside Acme.");
+    expect(out).toContain("## Capabilities");
+    expect(out).toContain("- PCI-aware checkout hosted by Stripe");
+    expect(out).toContain("- Webhooks for payment lifecycle events");
+    expect(out).toContain("## Setup");
+    expect(out).toContain("1. Create a Stripe account");
+    expect(out).toContain("## Pricing");
+    expect(out).toContain("Stripe processing fees apply");
+    expect(out).toContain("## Requirements");
+    expect(out).toContain("- Acme Business plan");
+    expect(out).toContain("- **URL**: https://acme.test/integrations/stripe");
+    expect(out).toContain("See the [Stripe docs](https://stripe.com/docs) for API details.");
+  });
+
+  it("works with minimal data", () => {
+    const c = integrationConverter({ siteUrl: SITE, basePath: "/i" });
+    const out = c({
+      id: "slack",
+      data: {
+        title: "Slack",
+        vendor: "Slack Technologies",
+        category: [],
+        description: "",
+        capabilities: ["Post messages to a channel"],
+      },
+    });
+    expect(out).toContain("# Slack");
+    expect(out).toContain("## Capabilities");
+    expect(out).toContain("- Post messages to a channel");
+    expect(out).toContain("/i/slack");
+  });
+
+  it("uses vendor or entry id when title is blank or missing at runtime", () => {
+    const c = integrationConverter({ siteUrl: SITE, basePath: "/integrations" });
+    expect(
+      c({
+        id: "stripe",
+        data: {
+          title: "   ",
+          vendor: "Stripe",
+          category: [],
+          description: "",
+          capabilities: ["x"],
+        },
+      }),
+    ).toContain("# Stripe");
+
+    expect(
+      c({
+        id: "orphan",
+        data: {
+          title: "",
+          vendor: "",
+          category: [],
+          description: "",
+          capabilities: [],
+        } as IntegrationEntryData,
+      }),
+    ).toContain("# orphan");
+
+    expect(
+      c({
+        id: "slack",
+        data: {
+          title: undefined as unknown as string,
+          vendor: "Slack",
+          category: [],
+          description: "",
+          capabilities: [],
+        },
+      }),
+    ).toContain("# Slack");
   });
 });
 
@@ -489,7 +591,7 @@ describe("docsConverter", () => {
 });
 
 describe("BUILT_IN_CONVERTERS export", () => {
-  it("lists all 12 generic built-in names in alphabetical order", () => {
+  it("lists all 13 generic built-in names in alphabetical order", () => {
     expect(BUILT_IN_CONVERTERS).toEqual([
       "blog",
       "case-study",
@@ -498,6 +600,7 @@ describe("BUILT_IN_CONVERTERS export", () => {
       "docs",
       "feature",
       "glossary",
+      "integration",
       "legal",
       "pricing",
       "pseo",

--- a/packages/converters/test/converters.test.ts
+++ b/packages/converters/test/converters.test.ts
@@ -158,7 +158,7 @@ describe("integrationConverter", () => {
       data: {
         title: "Connect Stripe to Acme",
         vendor: "Stripe",
-        category: ["Payments", "Finance"],
+        categories: ["Payments", "Finance"],
         description: "Accept cards and subscriptions inside Acme.",
         capabilities: [
           "PCI-aware checkout hosted by Stripe",
@@ -195,7 +195,7 @@ describe("integrationConverter", () => {
       data: {
         title: "Slack",
         vendor: "Slack Technologies",
-        category: [],
+        categories: [],
         description: "",
         capabilities: ["Post messages to a channel"],
       },
@@ -206,6 +206,26 @@ describe("integrationConverter", () => {
     expect(out).toContain("/i/slack");
   });
 
+  it("includes brandFooter when supplied", () => {
+    const c = integrationConverter({
+      siteUrl: SITE,
+      basePath: "/integrations",
+      brandFooter: "## About Acme\n\nMarketplace connectors.",
+    });
+    const out = c({
+      id: "hubspot",
+      data: {
+        title: "HubSpot",
+        vendor: "HubSpot",
+        categories: ["CRM"],
+        description: "Sync contacts.",
+        capabilities: ["Bi-directional sync"],
+      },
+    });
+    expect(out).toContain("## About Acme");
+    expect(out).toContain("Marketplace connectors.");
+  });
+
   it("uses vendor or entry id when title is blank or missing at runtime", () => {
     const c = integrationConverter({ siteUrl: SITE, basePath: "/integrations" });
     expect(
@@ -214,7 +234,7 @@ describe("integrationConverter", () => {
         data: {
           title: "   ",
           vendor: "Stripe",
-          category: [],
+          categories: [],
           description: "",
           capabilities: ["x"],
         },
@@ -227,7 +247,7 @@ describe("integrationConverter", () => {
         data: {
           title: "",
           vendor: "",
-          category: [],
+          categories: [],
           description: "",
           capabilities: [],
         } as IntegrationEntryData,
@@ -240,7 +260,7 @@ describe("integrationConverter", () => {
         data: {
           title: undefined as unknown as string,
           vendor: "Slack",
-          category: [],
+          categories: [],
           description: "",
           capabilities: [],
         },

--- a/packages/nextjs/src/converter-registry.ts
+++ b/packages/nextjs/src/converter-registry.ts
@@ -11,6 +11,7 @@ import {
   docsConverter,
   featureConverter,
   glossaryConverter,
+  integrationConverter,
   legalConverter,
   pricingConverter,
   pseoConverter,
@@ -29,6 +30,7 @@ export type BuiltInConverterName =
   | "docs"
   | "feature"
   | "glossary"
+  | "integration"
   | "legal"
   | "pricing"
   | "pseo"
@@ -63,6 +65,8 @@ export function resolveBuiltInConverter(
       return featureConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "glossary":
       return glossaryConverter(cfg) as Converter<CollectionEntry<unknown>>;
+    case "integration":
+      return integrationConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "legal":
       return legalConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "pricing":
@@ -75,7 +79,7 @@ export function resolveBuiltInConverter(
       return videoConverter(cfg) as Converter<CollectionEntry<unknown>>;
     default:
       throw new Error(
-        `Dualmark: unknown built-in converter '${args.name}'. Valid names: blog, case-study, changelog, compare, docs, feature, glossary, legal, pricing, pseo, tool, video. Or pass a function.`,
+        `Dualmark: unknown built-in converter '${args.name}'. Valid names: blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, tool, video. Or pass a function.`,
       );
   }
 }


### PR DESCRIPTION
## Summary

  Adds `integrationConverter` and the built-in name `integration` for marketplace-style integration pages (vendor, categories, capabilities, optional setup/pricing/requirements), with Astro and Next.js resolver wiring, tests, docs, and a changeset for `@dualmark/converters`. Closes #13 .

## Changes

- `integrationConverter` in `@dualmark/converters` (capabilities-first markdown; heading falls back title → vendor → slug).
- Export + `BUILT_IN_CONVERTERS`; Astro/Next `converter-registry` updates.
- Tests, README/docs updates for the new converter, changeset (minor).
  
## Type

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change
- [ ] Spec change (requires bump in `AEO_SPEC_VERSION`)
- [ ] Docs / examples / tooling only

## Verification

- [x] `bun run build` passes
- [x] `bun run test` passes
- [x] `bun run typecheck` passes
- [ ] If touching examples: ran `dualmark verify` against the example end-to-end
- [ ] If touching `/spec/`: ran `bun run --filter dualmark-docs sync-spec` and committed the mirror

## Changeset

- [x] Added a changeset (`bun run changeset`) for any package with a user-visible change
