### PR TITLE
docs: add public roadmap page

### DIFF
--- a/.changeset/thin-rocks-share.md
+++ b/.changeset/thin-rocks-share.md
@@ -1,0 +1,5 @@
+---
+"dualmark-docs": patch
+---
+
+Add a published public roadmap page and surface it from the docs landing page.

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ bun run build && bun run test && bun run typecheck   # 324 tests across 6 packag
 
 ## Where it goes from here
 
-We're building toward Dualmark being **the** AEO infrastructure for marketing sites — the same way Tailwind became the default for marketing CSS or Vercel for marketing hosting. The roadmap:
+We're building toward Dualmark being **the** AEO infrastructure for marketing sites — the same way Tailwind became the default for marketing CSS or Vercel for marketing hosting. The roadmap is also published at [dualmark.dev/docs/roadmap](https://dualmark.dev/docs/roadmap):
 
 - **More framework adapters**: SvelteKit, Remix/React Router, Nuxt
 - **More edge adapters**: Vercel, Netlify, Fastly Compute, Deno Deploy

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -42,8 +42,8 @@ Built and battle-tested at [Dodo Payments](https://dodopayments.com).
   <Card icon={<Rocket />} title="Quickstart" href="/docs/quickstart" description="Pick your stack — Astro, Next.js, Cloudflare, or any framework. Up and running in under 2 minutes." />
   <Card icon={<Gauge />} title="Score your site" href="/play" description="Free AI agent readiness check. Get a 0–125 score against the AEO Spec." />
   <Card icon={<Lightbulb />} title="Core concepts" href="/docs/concepts" description="How content negotiation, the markdown twin pattern, and AI bot detection work." />
-  <Card icon={<Map />} title="Roadmap" href="/docs/roadmap" description="See the public roadmap, linked sub-issues, and where to contribute next." />
   <Card icon={<BookText />} title="AEO Spec v1.0" href="/docs/spec/overview" description="The public spec any server can implement — RFC-2119 compliant, language-neutral." />
+  <Card icon={<Map />} title="Roadmap" href="/docs/roadmap" description="See the public roadmap, linked sub-issues, and where to contribute next." />
 </Cards>
 
 ## Pick your stack

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -8,6 +8,7 @@ import {
   Rocket,
   Gauge,
   Lightbulb,
+  Map,
   BookText,
   Wrench,
   Box,
@@ -41,6 +42,7 @@ Built and battle-tested at [Dodo Payments](https://dodopayments.com).
   <Card icon={<Rocket />} title="Quickstart" href="/docs/quickstart" description="Pick your stack — Astro, Next.js, Cloudflare, or any framework. Up and running in under 2 minutes." />
   <Card icon={<Gauge />} title="Score your site" href="/play" description="Free AI agent readiness check. Get a 0–125 score against the AEO Spec." />
   <Card icon={<Lightbulb />} title="Core concepts" href="/docs/concepts" description="How content negotiation, the markdown twin pattern, and AI bot detection work." />
+  <Card icon={<Map />} title="Roadmap" href="/docs/roadmap" description="See the public roadmap, linked sub-issues, and where to contribute next." />
   <Card icon={<BookText />} title="AEO Spec v1.0" href="/docs/spec/overview" description="The public spec any server can implement — RFC-2119 compliant, language-neutral." />
 </Cards>
 

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -4,6 +4,7 @@
     "---[Rocket]Get started---",
     "quickstart",
     "concepts",
+    "roadmap",
     "---[Plug]Integrate---",
     "...integrations",
     "---[Package]API reference---",

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -4,7 +4,6 @@
     "---[Rocket]Get started---",
     "quickstart",
     "concepts",
-    "roadmap",
     "---[Plug]Integrate---",
     "...integrations",
     "---[Package]API reference---",
@@ -12,6 +11,8 @@
     "---[ShieldCheck]Conformance---",
     "...conformance",
     "---[BookText]Spec---",
-    "...spec"
+    "...spec",
+    "---[Map]Project---",
+    "roadmap"
   ]
 }

--- a/apps/docs/content/docs/roadmap.mdx
+++ b/apps/docs/content/docs/roadmap.mdx
@@ -24,12 +24,12 @@ If something here matters to your stack and is not moving, add a `+1` or comment
 ## Converters
 
 - [ ] [#12 `status-page` converter](https://github.com/dodopayments/dualmark/issues/12)
-- [ ] [#13 `integration` / app-listing converter](https://github.com/dodopayments/dualmark/issues/13)
-- [ ] [#14 `api-reference` converter (OpenAPI-aware)](https://github.com/dodopayments/dualmark/issues/14)
+- [x] [#13 `integration` / app-listing converter](https://github.com/dodopayments/dualmark/issues/13) — shipped in [v0.7.0](https://github.com/dodopayments/dualmark/releases/tag/v0.7.0)
+- [ ] [#14 `api-reference` converter (OpenAPI-aware)](https://github.com/dodopayments/dualmark/issues/14) — PR open: [#47](https://github.com/dodopayments/dualmark/pull/47)
 
 ## Core, CLI, and spec
 
-- [ ] [#15 extend AI-bot detection list](https://github.com/dodopayments/dualmark/issues/15)
+- [x] [#15 extend AI-bot detection list](https://github.com/dodopayments/dualmark/issues/15) — shipped in [v0.7.0](https://github.com/dodopayments/dualmark/releases/tag/v0.7.0)
 - [ ] [#16 CLI `--json` output](https://github.com/dodopayments/dualmark/issues/16)
 - [ ] [#17 official GitHub Action wrapper](https://github.com/dodopayments/dualmark/issues/17)
 - [ ] [#18 AEO Spec v1.1 draft](https://github.com/dodopayments/dualmark/issues/18)

--- a/apps/docs/content/docs/roadmap.mdx
+++ b/apps/docs/content/docs/roadmap.mdx
@@ -1,0 +1,55 @@
+---
+title: Public roadmap
+description: The current paths to AEO ubiquity, grouped by track and linked to the source GitHub issues.
+---
+
+Public roadmap for Dualmark. The linked GitHub sub-issues are the source of truth for scope, discussion, and prioritization.
+
+If something here matters to your stack and is not moving, add a `+1` or comment on the sub-issue so the maintainers can prioritize it.
+
+## Framework adapters
+
+- [x] [#4 `@dualmark/nextjs`](https://github.com/dodopayments/dualmark/issues/4) — shipped in [v0.5.0](https://github.com/dodopayments/dualmark/releases/tag/v0.5.0)
+- [ ] [#5 `@dualmark/sveltekit`](https://github.com/dodopayments/dualmark/issues/5)
+- [ ] [#6 `@dualmark/remix` / React Router v7](https://github.com/dodopayments/dualmark/issues/6)
+- [ ] [#7 `@dualmark/nuxt`](https://github.com/dodopayments/dualmark/issues/7)
+
+## Edge adapters
+
+- [ ] [#8 `@dualmark/vercel` (Edge Middleware)](https://github.com/dodopayments/dualmark/issues/8)
+- [ ] [#9 `@dualmark/netlify` (Edge Functions)](https://github.com/dodopayments/dualmark/issues/9)
+- [ ] [#10 `@dualmark/fastly` (Compute@Edge)](https://github.com/dodopayments/dualmark/issues/10)
+- [ ] [#11 `@dualmark/deno` (Deno Deploy)](https://github.com/dodopayments/dualmark/issues/11)
+
+## Converters
+
+- [ ] [#12 `status-page` converter](https://github.com/dodopayments/dualmark/issues/12)
+- [ ] [#13 `integration` / app-listing converter](https://github.com/dodopayments/dualmark/issues/13)
+- [ ] [#14 `api-reference` converter (OpenAPI-aware)](https://github.com/dodopayments/dualmark/issues/14)
+
+## Core, CLI, and spec
+
+- [ ] [#15 extend AI-bot detection list](https://github.com/dodopayments/dualmark/issues/15)
+- [ ] [#16 CLI `--json` output](https://github.com/dodopayments/dualmark/issues/16)
+- [ ] [#17 official GitHub Action wrapper](https://github.com/dodopayments/dualmark/issues/17)
+- [ ] [#18 AEO Spec v1.1 draft](https://github.com/dodopayments/dualmark/issues/18)
+- [ ] [#21 pluggable token estimator](https://github.com/dodopayments/dualmark/issues/21)
+
+## Examples and docs
+
+- [ ] [#19 CMS-driven (Sanity/Contentful) example](https://github.com/dodopayments/dualmark/issues/19)
+- [ ] [#20 "Use in CI" docs guide](https://github.com/dodopayments/dualmark/issues/20)
+- [ ] [#22 starter contributions board](https://github.com/dodopayments/dualmark/issues/22)
+
+## How to contribute
+
+1. Pick a sub-issue that matches your stack or interest.
+2. Comment on that issue to claim it or propose a smaller split.
+3. Read the repo [contribution guide](https://github.com/dodopayments/dualmark/blob/main/CONTRIBUTING.md).
+4. Open a PR with tests, typecheck, and any required changeset included.
+
+## Out of scope for now
+
+- New runtime dependencies in `@dualmark/core` — it stays zero-dependency.
+- Breaking changes to AEO Spec v1.0 — those flow through [#18](https://github.com/dodopayments/dualmark/issues/18).
+- Hosted services or dashboards — tracked separately from the OSS roadmap.


### PR DESCRIPTION
## Summary
Add a published public roadmap page to the docs site and link it from the existing docs surfaces so issue #23 has a canonical public page instead of only the GitHub issue body.

## Changes
- add `/docs/roadmap` with the current roadmap tracks, sub-issue links, contribution guidance, and out-of-scope notes
- surface the roadmap from the docs landing page and docs nav metadata
- add a README pointer to the published roadmap and include a `dualmark-docs` changeset for the user-visible docs change

## Type
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Spec change (requires bump in `AEO_SPEC_VERSION`)
- [x] Docs / examples / tooling only

## Verification
- [x] `bun run build` passes
- [x] `bun run test` passes
- [ ] `bun run typecheck` passes
- [ ] If touching examples: ran `dualmark verify` against the example end-to-end
- [ ] If touching `/spec/`: ran `bun run --filter dualmark-docs sync-spec` and committed the mirror

`bun run typecheck` currently fails on `origin/main` in `@dualmark/nextjs` during DTS build with `TS7016: Could not find a declaration file for module '@dualmark/converters'`, so I did not mark that box as passed.

## Changeset
- [x] Added a changeset (`bun run changeset`) for any package with a user-visible change

Fixes #23.