### PR TITLE
feat: add API reference converter

### DIFF
--- a/.changeset/sixty-flowers-grin.md
+++ b/.changeset/sixty-flowers-grin.md
@@ -1,0 +1,5 @@
+---
+"@dualmark/converters": patch
+---
+
+Add the built-in API reference converter with an OpenAPI projection helper.

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ You already invested in SEO. Now invest in AEO — for **a fraction of the effor
 | **`llms.txt` proposal keeps changing** | Hand-maintained, drifts from sitemap | Auto-generated from the same config that drives your routes |
 | **Every team rebuilds this** | Custom middleware in every repo, none of them quite right | One battle-tested package, conforms to a public spec |
 | **No analytics for AI traffic** | "Was that a bot or a human?" | `onAIRequest` hook + Cloudflare Analytics Engine integration: bot name, vendor, page, tokens, country |
-| **Slow to roll out across pages** | Marketing waits weeks for engineering | Add `converter: "compare"` to a collection — done. 13 converters bundled. |
+| **Slow to roll out across pages** | Marketing waits weeks for engineering | Add `converter: "compare"` to a collection — done. 14 converters bundled. |
 
 **Built and battle-tested at [Dodo Payments](https://dodopayments.com)** for our own marketing site. Now extracted as OSS so you don't have to write the same content negotiation, bot detection, and edge wrapping over and over.
 
@@ -240,7 +240,7 @@ Three conformance levels — **Basic** (60%), **Standard** (80%), **Advanced** (
 | Package | npm | Size | What it does |
 |---|---|---|---|
 | [`@dualmark/core`](./packages/core) | `npm i @dualmark/core` | 14 KB | Framework-agnostic primitives: content negotiation (RFC 7231), AI-bot detection (24 known bots), markdown response builder, token estimation, composition helpers, `llms.txt` rendering. Zero runtime deps. |
-| [`@dualmark/converters`](./packages/converters) | `npm i @dualmark/converters` | 16 KB | 13 production-tested converter factories. |
+| [`@dualmark/converters`](./packages/converters) | `npm i @dualmark/converters` | 16 KB | 14 production-tested converter factories. |
 | [`@dualmark/astro`](./packages/astro) | `npm i @dualmark/astro` | 22 KB | Astro 5 integration. Auto-generates `.md` endpoints, ships middleware, generates `llms.txt`. |
 | [`@dualmark/nextjs`](./packages/nextjs) | `npm i @dualmark/nextjs` | 15 KB | Next.js App Router adapter. `withDualmark()`, `createDualmarkMiddleware()`, `createDualmarkRouteHandler()`, `createLlmsTxtHandler()`. |
 | [`@dualmark/cloudflare`](./packages/cloudflare) | `npm i @dualmark/cloudflare` | 9 KB | Workers edge adapter. Wraps any upstream Worker. Hooks for analytics + telemetry. |
@@ -260,7 +260,7 @@ Plus:
 | Surface | Status |
 |---|---|
 | `@dualmark/core` | 174 tests pass (vitest + fast-check property tests) |
-| `@dualmark/converters` | 28 tests pass |
+| `@dualmark/converters` | 32 tests pass |
 | `@dualmark/cloudflare` | 23 tests pass |
 | `@dualmark/cli` | 17 tests pass |
 | `@dualmark/astro` | 35 tests pass |
@@ -284,7 +284,7 @@ We're building toward Dualmark being **the** AEO infrastructure for marketing si
 
 - **More framework adapters**: SvelteKit, Remix/React Router, Nuxt
 - **More edge adapters**: Vercel, Netlify, Fastly Compute, Deno Deploy
-- **More converters**: pricing tables, changelog, docs/API reference, status pages, integrations
+- **More converters**: status pages, richer integration catalogs, and deeper schema-aware formats
 - **AEO Analytics**: a hosted dashboard on top of the `onAIRequest` hook, so marketing can see which bot reads which page, when
 - **Spec evolution toward AEO 1.1+** with structured data hints, per-section markdown anchors, and sitemap.md
 - **CMS integrations**: Sanity, Contentful, Builder.io plugins so non-engineers can author dual-marked content

--- a/apps/docs/app/_components/adapters.tsx
+++ b/apps/docs/app/_components/adapters.tsx
@@ -127,7 +127,7 @@ export function Adapters() {
 
       <div className="mt-10 flex flex-col items-center gap-3 text-center">
         <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--color-fg-subtle)]">
-          + 12 page-type converters
+          + 13 page-type converters
         </span>
         <div className="flex flex-wrap items-center justify-center gap-1.5">
           {CONVERTERS.map((name) => (

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -57,7 +57,7 @@ Built and battle-tested at [Dodo Payments](https://dodopayments.com).
 
 <Cards>
   <Card icon={<Box />} title="@dualmark/core" href="/docs/packages/core" description="Framework-agnostic primitives — content negotiation, AI-bot detection, markdown responses." />
-  <Card icon={<ArrowLeftRight />} title="@dualmark/converters" href="/docs/packages/converters" description="13 production-tested page-type converters — blog, glossary, integration, pricing, changelog, and more." />
+  <Card icon={<ArrowLeftRight />} title="@dualmark/converters" href="/docs/packages/converters" description="14 production-tested page-type converters — blog, glossary, integration, pricing, API reference, and more." />
   <Card icon={<AstroLogo />} title="@dualmark/astro" href="/docs/packages/astro" description="Astro 5 integration with auto-generated routes and llms.txt." />
   <Card icon={<NextLogo />} title="@dualmark/nextjs" href="/docs/packages/nextjs" description="Next.js 15 App Router adapter — withDualmark, middleware factory, route handler factory." />
   <Card icon={<CloudflareLogo />} title="@dualmark/cloudflare" href="/docs/packages/cloudflare" description="Workers edge adapter with hooks for analytics and transformations." />

--- a/apps/docs/content/docs/integrations/astro.mdx
+++ b/apps/docs/content/docs/integrations/astro.mdx
@@ -108,7 +108,7 @@ dualmark({
 
 ## Available converters
 
-`converter: "blog" | "case-study" | "changelog" | "compare" | "docs" | "feature" | "glossary" | "integration" | "legal" | "pricing" | "pseo" | "tool" | "video"` — see [@dualmark/converters](/docs/packages/converters).
+`converter: "api-reference" | "blog" | "case-study" | "changelog" | "compare" | "docs" | "feature" | "glossary" | "integration" | "legal" | "pricing" | "pseo" | "tool" | "video"` — see [@dualmark/converters](/docs/packages/converters).
 
 You can also pass a custom function: `converter: (entry) => string`.
 

--- a/apps/docs/content/docs/integrations/nextjs.mdx
+++ b/apps/docs/content/docs/integrations/nextjs.mdx
@@ -158,7 +158,7 @@ export const GET = handler.GET;
 
 ## Built-in converter names
 
-`blog`, `case-study`, `changelog`, `compare`, `docs`, `feature`, `glossary`, `integration`, `legal`, `pricing`, `pseo`, `tool`, `video` — see [@dualmark/converters](/docs/packages/converters). Or pass a custom function `(entry) => string`.
+`api-reference`, `blog`, `case-study`, `changelog`, `compare`, `docs`, `feature`, `glossary`, `integration`, `legal`, `pricing`, `pseo`, `tool`, `video` — see [@dualmark/converters](/docs/packages/converters). Or pass a custom function `(entry) => string`.
 
 ## Verify
 

--- a/apps/docs/content/docs/packages/converters.mdx
+++ b/apps/docs/content/docs/packages/converters.mdx
@@ -1,6 +1,6 @@
 ---
 title: "@dualmark/converters"
-description: 13 production-tested markdown converter factories.
+description: 14 production-tested markdown converter factories.
 ---
 
 <Tabs items={["bun", "npm", "yarn"]}>
@@ -27,6 +27,7 @@ Each factory takes a config object and returns `(entry: CollectionEntry<Data>) =
 
 | Factory | Domain |
 | --- | --- |
+| `apiReferenceConverter` | API endpoint references (manual shape or OpenAPI-derived) |
 | `blogConverter` | Blog posts |
 | `caseStudyConverter` | Case studies (with stats + customer quote) |
 | `changelogConverter` | Release notes (Keep-a-Changelog grouping) |
@@ -40,6 +41,8 @@ Each factory takes a config object and returns `(entry: CollectionEntry<Data>) =
 | `pseoConverter` | Programmatic SEO pages with facts + related-link groups |
 | `toolConverter` | Standalone tools |
 | `videoConverter` | Video pages |
+
+The package now ships 14 built-in converters.
 
 ## Common shape
 

--- a/packages/converters/README.md
+++ b/packages/converters/README.md
@@ -12,6 +12,7 @@ bun add @dualmark/converters @dualmark/core
 
 | Factory | Domain |
 |---|---|
+| `apiReferenceConverter` | API endpoint references (manual shape or OpenAPI-derived) |
 | `blogConverter` | Blog posts |
 | `caseStudyConverter` | Case studies (with stats + customer quote) |
 | `changelogConverter` | Release notes (Keep-a-Changelog grouping) |
@@ -26,10 +27,12 @@ bun add @dualmark/converters @dualmark/core
 | `toolConverter` | Standalone tools |
 | `videoConverter` | Video pages |
 
+That includes 14 built-in converters in total.
+
 ## Usage
 
 ```ts
-import { blogConverter } from "@dualmark/converters";
+import { apiReferenceConverter, blogConverter, fromOpenAPI } from "@dualmark/converters";
 
 const convert = blogConverter({
   siteUrl: "https://example.com",
@@ -42,6 +45,12 @@ const md = convert({
   data: { title: "Hello", publishedDate: new Date(), author: "Alice" },
   body: "Long-form content.",
 });
+
+const endpoint = fromOpenAPI(parsedOpenApiDoc, "addPet");
+const endpointMd = apiReferenceConverter({
+  siteUrl: "https://example.com",
+  basePath: "/api-reference",
+})(endpoint);
 ```
 
 Each factory takes a config object and returns a `(entry) => string` converter. Pass them to `@dualmark/astro` collection config or call directly from your own framework.

--- a/packages/converters/package.json
+++ b/packages/converters/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dualmark/converters",
   "version": "0.5.2",
-  "description": "13 production-tested markdown converter factories (blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, tool, video) for the Dualmark AEO framework.",
+  "description": "14 production-tested markdown converter factories (api-reference, blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, tool, video) for the Dualmark AEO framework.",
   "license": "Apache-2.0",
   "author": "Dodo Payments <opensource@dodopayments.com> (https://dodopayments.com)",
   "repository": {

--- a/packages/converters/src/api-reference.ts
+++ b/packages/converters/src/api-reference.ts
@@ -1,0 +1,641 @@
+import { cleanBody, joinLines, normalizeUnicode } from "@dualmark/core";
+import type { BaseConverterConfig, CollectionEntry, Converter } from "./types.js";
+
+export interface ApiReferenceConverterConfig extends BaseConverterConfig {
+  basePath?: string;
+}
+
+export interface ApiReferenceField {
+  name: string;
+  type: string;
+  required?: boolean;
+  description?: string;
+}
+
+export interface ApiReferenceParameter {
+  name: string;
+  in: "path" | "query" | "header" | "cookie";
+  type: string;
+  required?: boolean;
+  description?: string;
+}
+
+export interface ApiReferenceMediaType {
+  contentType: string;
+  schema?: string;
+  fields?: ApiReferenceField[];
+}
+
+export interface ApiReferenceRequestBody {
+  description?: string;
+  required?: boolean;
+  contents: ApiReferenceMediaType[];
+}
+
+export interface ApiReferenceResponse {
+  status: string;
+  description?: string;
+  contents?: ApiReferenceMediaType[];
+}
+
+export interface ApiReferenceCodeSample {
+  lang: string;
+  label?: string;
+  source: string;
+}
+
+export interface ApiReferenceEntryData {
+  title: string;
+  summary?: string;
+  description?: string;
+  method: string;
+  path: string;
+  pagePath?: string;
+  tags?: string[];
+  parameters?: ApiReferenceParameter[];
+  requestBody?: ApiReferenceRequestBody;
+  responses: ApiReferenceResponse[];
+  codeSamples?: ApiReferenceCodeSample[];
+}
+
+type HttpMethod =
+  | "get"
+  | "put"
+  | "post"
+  | "delete"
+  | "options"
+  | "head"
+  | "patch"
+  | "trace";
+
+interface OpenAPIReferenceObject {
+  $ref: string;
+}
+
+interface OpenAPISchemaObject {
+  title?: string;
+  type?: string | string[];
+  format?: string;
+  description?: string;
+  enum?: unknown[];
+  const?: unknown;
+  items?: OpenAPISchema;
+  properties?: Record<string, OpenAPISchema>;
+  required?: string[];
+  oneOf?: OpenAPISchema[];
+  anyOf?: OpenAPISchema[];
+  allOf?: OpenAPISchema[];
+  nullable?: boolean;
+  additionalProperties?: boolean | OpenAPISchema;
+}
+
+type OpenAPISchema = OpenAPISchemaObject | OpenAPIReferenceObject;
+
+interface OpenAPIMediaTypeObject {
+  schema?: OpenAPISchema;
+}
+
+interface OpenAPIParameterObject {
+  name: string;
+  in: "path" | "query" | "header" | "cookie";
+  description?: string;
+  required?: boolean;
+  schema?: OpenAPISchema;
+  content?: Record<string, OpenAPIMediaTypeObject>;
+}
+
+type OpenAPIParameter = OpenAPIParameterObject | OpenAPIReferenceObject;
+
+interface OpenAPIRequestBodyObject {
+  description?: string;
+  required?: boolean;
+  content?: Record<string, OpenAPIMediaTypeObject>;
+}
+
+type OpenAPIRequestBody = OpenAPIRequestBodyObject | OpenAPIReferenceObject;
+
+interface OpenAPIResponseObject {
+  description?: string;
+  content?: Record<string, OpenAPIMediaTypeObject>;
+}
+
+type OpenAPIResponse = OpenAPIResponseObject | OpenAPIReferenceObject;
+
+interface OpenAPICodeSampleObject {
+  lang?: string;
+  language?: string;
+  label?: string;
+  source?: string;
+  sourceString?: string;
+  code?: string;
+}
+
+interface OpenAPIOperationObject {
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  tags?: string[];
+  parameters?: OpenAPIParameter[];
+  requestBody?: OpenAPIRequestBody;
+  responses?: Record<string, OpenAPIResponse>;
+  "x-codeSamples"?: OpenAPICodeSampleObject[];
+}
+
+interface OpenAPIPathItemObject {
+  parameters?: OpenAPIParameter[];
+  get?: OpenAPIOperationObject;
+  put?: OpenAPIOperationObject;
+  post?: OpenAPIOperationObject;
+  delete?: OpenAPIOperationObject;
+  options?: OpenAPIOperationObject;
+  head?: OpenAPIOperationObject;
+  patch?: OpenAPIOperationObject;
+  trace?: OpenAPIOperationObject;
+}
+
+export interface OpenAPIDocument {
+  openapi?: string;
+  info?: {
+    title?: string;
+    version?: string;
+  };
+  paths: Record<string, OpenAPIPathItemObject>;
+  components?: {
+    schemas?: Record<string, OpenAPISchema>;
+    parameters?: Record<string, OpenAPIParameter>;
+    requestBodies?: Record<string, OpenAPIRequestBody>;
+    responses?: Record<string, OpenAPIResponse>;
+  };
+}
+
+function isParameterObject(value: unknown): value is OpenAPIParameterObject {
+  return (
+    isRecord(value) &&
+    typeof value.name === "string" &&
+    typeof value.in === "string" &&
+    ["path", "query", "header", "cookie"].includes(value.in)
+  );
+}
+
+const HTTP_METHODS: HttpMethod[] = [
+  "get",
+  "put",
+  "post",
+  "delete",
+  "options",
+  "head",
+  "patch",
+  "trace",
+];
+
+const CODE_BLOCK_LANGUAGE_ALIASES: Record<string, string> = {
+  curl: "bash",
+  shell: "bash",
+  sh: "bash",
+  javascript: "ts",
+  typescript: "ts",
+  node: "ts",
+  "node.js": "ts",
+  csharp: "csharp",
+  "c#": "csharp",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isReferenceObject(value: unknown): value is OpenAPIReferenceObject {
+  return isRecord(value) && typeof value.$ref === "string";
+}
+
+function asSchemaObject(schema: OpenAPISchema | undefined): OpenAPISchemaObject | undefined {
+  return schema && !isReferenceObject(schema) ? schema : undefined;
+}
+
+function resolveReference(spec: OpenAPIDocument, ref: string): unknown {
+  if (!ref.startsWith("#/")) return undefined;
+  const segments = ref
+    .slice(2)
+    .split("/")
+    .filter((segment) => segment.length > 0);
+
+  let current: unknown = spec;
+  for (const segment of segments) {
+    if (!isRecord(current)) return undefined;
+    current = current[segment];
+  }
+  return current;
+}
+
+function resolveSchema(
+  spec: OpenAPIDocument,
+  schema: OpenAPISchema | undefined,
+  seenRefs: Set<string> = new Set(),
+): OpenAPISchemaObject | undefined {
+  if (!schema) return undefined;
+  if (!isReferenceObject(schema)) return schema;
+  if (seenRefs.has(schema.$ref)) return undefined;
+  seenRefs.add(schema.$ref);
+  const resolved = resolveReference(spec, schema.$ref);
+  if (isReferenceObject(resolved)) {
+    return resolveSchema(spec, resolved, seenRefs);
+  }
+  return isRecord(resolved) ? (resolved as OpenAPISchemaObject) : undefined;
+}
+
+function resolveParameter(
+  spec: OpenAPIDocument,
+  parameter: OpenAPIParameter,
+): OpenAPIParameterObject | undefined {
+  if (!isReferenceObject(parameter)) return parameter;
+  const resolved = resolveReference(spec, parameter.$ref);
+  return isParameterObject(resolved) ? resolved : undefined;
+}
+
+function resolveRequestBody(
+  spec: OpenAPIDocument,
+  requestBody: OpenAPIRequestBody | undefined,
+): OpenAPIRequestBodyObject | undefined {
+  if (!requestBody) return undefined;
+  if (!isReferenceObject(requestBody)) return requestBody;
+  const resolved = resolveReference(spec, requestBody.$ref);
+  return isRecord(resolved) ? (resolved as OpenAPIRequestBodyObject) : undefined;
+}
+
+function resolveResponse(
+  spec: OpenAPIDocument,
+  response: OpenAPIResponse,
+): OpenAPIResponseObject | undefined {
+  if (!isReferenceObject(response)) return response;
+  const resolved = resolveReference(spec, response.$ref);
+  return isRecord(resolved) ? (resolved as OpenAPIResponseObject) : undefined;
+}
+
+function stringifyEnumValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
+function formatTypeName(type: string, format?: string): string {
+  return format ? `${type}(${format})` : type;
+}
+
+function renderSchemaSummary(spec: OpenAPIDocument, schema: OpenAPISchema | undefined): string {
+  const resolved = resolveSchema(spec, schema);
+  if (!resolved) return "unknown";
+
+  if (resolved.allOf && resolved.allOf.length > 0) {
+    return resolved.allOf.map((item) => renderSchemaSummary(spec, item)).join(" & ");
+  }
+  if (resolved.oneOf && resolved.oneOf.length > 0) {
+    return `oneOf<${resolved.oneOf.map((item) => renderSchemaSummary(spec, item)).join(" | ")}>`;
+  }
+  if (resolved.anyOf && resolved.anyOf.length > 0) {
+    return `anyOf<${resolved.anyOf.map((item) => renderSchemaSummary(spec, item)).join(" | ")}>`;
+  }
+
+  const rawType = resolved.type;
+  const typeName = Array.isArray(rawType)
+    ? rawType.join(" | ")
+    : rawType ?? (resolved.properties ? "object" : resolved.items ? "array" : "unknown");
+
+  let summary = typeName;
+  if (typeName === "array") {
+    summary = `array<${renderSchemaSummary(spec, resolved.items)}>`;
+  } else if (typeName === "object" && resolved.additionalProperties === true) {
+    summary = "object<string, unknown>";
+  } else if (typeName === "object" && resolved.additionalProperties && resolved.additionalProperties !== true) {
+    summary = `object<string, ${renderSchemaSummary(spec, resolved.additionalProperties)}>`;
+  } else if (!Array.isArray(rawType) && typeof rawType === "string") {
+    summary = formatTypeName(rawType, resolved.format);
+  }
+
+  if (resolved.enum && resolved.enum.length > 0) {
+    summary += ` enum(${resolved.enum.map(stringifyEnumValue).join(", ")})`;
+  } else if (resolved.const !== undefined) {
+    summary += ` = ${stringifyEnumValue(resolved.const)}`;
+  }
+
+  if (resolved.nullable) {
+    summary += " | null";
+  }
+
+  return summary;
+}
+
+function collectSchemaFields(
+  spec: OpenAPIDocument,
+  schema: OpenAPISchema | undefined,
+  prefix = "",
+): ApiReferenceField[] {
+  const resolved = resolveSchema(spec, schema);
+  if (!resolved) return [];
+
+  if (resolved.allOf && resolved.allOf.length > 0) {
+    return resolved.allOf.flatMap((item) => collectSchemaFields(spec, item, prefix));
+  }
+  if (resolved.oneOf && resolved.oneOf.length > 0) {
+    return resolved.oneOf.flatMap((item) => collectSchemaFields(spec, item, prefix));
+  }
+  if (resolved.anyOf && resolved.anyOf.length > 0) {
+    return resolved.anyOf.flatMap((item) => collectSchemaFields(spec, item, prefix));
+  }
+
+  if (resolved.type === "array" || resolved.items) {
+    const arrayPrefix = prefix ? `${prefix}[]` : "[]";
+    return collectSchemaFields(spec, resolved.items, arrayPrefix);
+  }
+
+  if (!resolved.properties || Object.keys(resolved.properties).length === 0) {
+    return [];
+  }
+
+  const requiredFields = new Set(resolved.required ?? []);
+  const fields: ApiReferenceField[] = [];
+  for (const [propertyName, propertySchema] of Object.entries(resolved.properties)) {
+    const fieldName = prefix ? `${prefix}.${propertyName}` : propertyName;
+    const childResolved = resolveSchema(spec, propertySchema);
+    fields.push({
+      name: fieldName,
+      type: renderSchemaSummary(spec, propertySchema),
+      required: requiredFields.has(propertyName),
+      description: childResolved?.description,
+    });
+    fields.push(...collectSchemaFields(spec, propertySchema, fieldName));
+  }
+
+  return fields;
+}
+
+function renderFieldsTable(fields: ApiReferenceField[]): string {
+  if (fields.length === 0) return "";
+  const rows = fields.map((field) => {
+    const description = field.description ? field.description.replace(/\n+/g, " ") : "";
+    return `| \`${field.name}\` | \`${field.type}\` | ${field.required ? "yes" : "no"} | ${description} |`;
+  });
+  return [
+    "| Field | Type | Required | Description |",
+    "| --- | --- | --- | --- |",
+    ...rows,
+  ].join("\n");
+}
+
+function renderParametersTable(parameters: ApiReferenceParameter[]): string {
+  if (parameters.length === 0) return "";
+  const rows = parameters.map((parameter) => {
+    const description = parameter.description ? parameter.description.replace(/\n+/g, " ") : "";
+    return `| \`${parameter.name}\` | \`${parameter.in}\` | \`${parameter.type}\` | ${parameter.required ? "yes" : "no"} | ${description} |`;
+  });
+  return [
+    "| Name | In | Type | Required | Description |",
+    "| --- | --- | --- | --- | --- |",
+    ...rows,
+  ].join("\n");
+}
+
+function renderMediaTypeSection(content: ApiReferenceMediaType): string {
+  const parts: string[] = [`### \`${content.contentType}\``];
+  if (content.schema) {
+    parts.push(`- **Schema**: \`${content.schema}\``);
+  }
+  if (content.fields && content.fields.length > 0) {
+    parts.push("\n#### Fields\n");
+    parts.push(renderFieldsTable(content.fields));
+  }
+  return parts.join("\n\n");
+}
+
+function renderRequestBodySection(requestBody: ApiReferenceRequestBody): string {
+  const parts: string[] = ["## Request body"];
+  if (requestBody.description) {
+    parts.push(requestBody.description);
+  }
+  parts.push(`- **Required**: ${requestBody.required ? "yes" : "no"}`);
+  for (const content of requestBody.contents) {
+    parts.push(renderMediaTypeSection(content));
+  }
+  return parts.join("\n\n");
+}
+
+function renderResponsesSection(responses: ApiReferenceResponse[]): string {
+  const parts: string[] = ["## Responses"];
+  for (const response of responses) {
+    parts.push(`### \`${response.status}\``);
+    if (response.description) {
+      parts.push(response.description);
+    }
+    for (const content of response.contents ?? []) {
+      parts.push(renderMediaTypeSection(content));
+    }
+  }
+  return parts.join("\n\n");
+}
+
+function normalizeCodeBlockLanguage(lang: string): string {
+  const normalized = lang.trim().toLowerCase();
+  return CODE_BLOCK_LANGUAGE_ALIASES[normalized] ?? normalized.replace(/[^a-z0-9#+-]/g, "");
+}
+
+function renderCodeSamplesSection(codeSamples: ApiReferenceCodeSample[]): string {
+  const parts: string[] = ["## Code samples"];
+  for (const sample of codeSamples) {
+    const label = sample.label?.trim() || sample.lang;
+    const language = normalizeCodeBlockLanguage(sample.lang);
+    parts.push(`### ${label}`);
+    parts.push(`\`\`\`${language}\n${sample.source.trim()}\n\`\`\``);
+  }
+  return parts.join("\n\n");
+}
+
+function resolvePageUrl(
+  config: ApiReferenceConverterConfig,
+  entry: CollectionEntry<ApiReferenceEntryData>,
+): string {
+  const customPath = entry.data.pagePath?.trim();
+  if (customPath) {
+    if (/^https?:\/\//.test(customPath)) return customPath;
+    return `${config.siteUrl}${customPath.startsWith("/") ? customPath : `/${customPath}`}`;
+  }
+  const basePath = config.basePath ?? "/api";
+  return `${config.siteUrl}${basePath}/${entry.id}`;
+}
+
+export function apiReferenceConverter(
+  config: ApiReferenceConverterConfig,
+): Converter<CollectionEntry<ApiReferenceEntryData>> {
+  return (entry) => {
+    const data = entry.data;
+    const parts: string[] = [];
+
+    parts.push(
+      joinLines(
+        `# ${data.title}`,
+        data.summary && `\n> ${data.summary}`,
+        "",
+        `- **Method**: \`${data.method.toUpperCase()}\``,
+        `- **Path**: \`${data.path}\``,
+        `- **URL**: ${resolvePageUrl(config, entry)}`,
+        data.tags && data.tags.length > 0 && `- **Tags**: ${data.tags.join(", ")}`,
+      ),
+    );
+
+    if (data.description) {
+      parts.push(`\n${data.description}`);
+    }
+
+    if (data.parameters && data.parameters.length > 0) {
+      parts.push(`\n## Parameters\n\n${renderParametersTable(data.parameters)}`);
+    }
+
+    if (data.requestBody) {
+      parts.push(`\n${renderRequestBodySection(data.requestBody)}`);
+    }
+
+    parts.push(`\n${renderResponsesSection(data.responses)}`);
+
+    if (data.codeSamples && data.codeSamples.length > 0) {
+      parts.push(`\n${renderCodeSamplesSection(data.codeSamples)}`);
+    }
+
+    if (entry.body) {
+      parts.push(`\n---\n\n${cleanBody(entry.body)}`);
+    }
+
+    if (config.brandFooter) {
+      parts.push(`\n---\n${config.brandFooter}`);
+    }
+
+    return normalizeUnicode(parts.join("\n"));
+  };
+}
+
+function collectParameters(
+  spec: OpenAPIDocument,
+  pathItem: OpenAPIPathItemObject,
+  operation: OpenAPIOperationObject,
+): ApiReferenceParameter[] {
+  const merged = new Map<string, OpenAPIParameterObject>();
+  for (const candidate of [...(pathItem.parameters ?? []), ...(operation.parameters ?? [])]) {
+    const parameter = resolveParameter(spec, candidate);
+    if (!parameter) continue;
+    merged.set(`${parameter.in}:${parameter.name}`, parameter);
+  }
+
+  return [...merged.values()].map((parameter) => {
+    const firstContentSchema = parameter.content
+      ? Object.values(parameter.content)[0]?.schema
+      : undefined;
+    return {
+      name: parameter.name,
+      in: parameter.in,
+      type: renderSchemaSummary(spec, parameter.schema ?? firstContentSchema),
+      required: parameter.in === "path" ? true : parameter.required ?? false,
+      description: parameter.description,
+    };
+  });
+}
+
+function collectMediaTypes(
+  spec: OpenAPIDocument,
+  content: Record<string, OpenAPIMediaTypeObject> | undefined,
+): ApiReferenceMediaType[] {
+  if (!content) return [];
+  return Object.entries(content).map(([contentType, media]) => {
+    const fields = collectSchemaFields(spec, media.schema);
+    return {
+      contentType,
+      schema: renderSchemaSummary(spec, media.schema),
+      fields: fields.length > 0 ? fields : undefined,
+    };
+  });
+}
+
+function collectResponses(
+  spec: OpenAPIDocument,
+  responses: Record<string, OpenAPIResponse> | undefined,
+): ApiReferenceResponse[] {
+  if (!responses) return [];
+  return Object.entries(responses).map(([status, candidate]) => {
+    const response = resolveResponse(spec, candidate);
+    return {
+      status,
+      description: response?.description,
+      contents: collectMediaTypes(spec, response?.content),
+    };
+  });
+}
+
+function collectCodeSamples(operation: OpenAPIOperationObject): ApiReferenceCodeSample[] | undefined {
+  const samples = operation["x-codeSamples"];
+  if (!samples || samples.length === 0) return undefined;
+
+  const normalized = samples.flatMap((sample) => {
+    const lang = sample.lang ?? sample.language;
+    const source = sample.source ?? sample.sourceString ?? sample.code;
+    if (!lang || !source) return [];
+    return [
+      {
+        lang,
+        label: sample.label,
+        source,
+      },
+    ];
+  });
+
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function findOperation(
+  spec: OpenAPIDocument,
+  operationId: string,
+): {
+  path: string;
+  method: HttpMethod;
+  pathItem: OpenAPIPathItemObject;
+  operation: OpenAPIOperationObject;
+} | undefined {
+  for (const [path, pathItem] of Object.entries(spec.paths)) {
+    for (const method of HTTP_METHODS) {
+      const operation = pathItem[method];
+      if (operation?.operationId === operationId) {
+        return { path, method, pathItem, operation };
+      }
+    }
+  }
+  return undefined;
+}
+
+export function fromOpenAPI(
+  spec: OpenAPIDocument,
+  operationId: string,
+): CollectionEntry<ApiReferenceEntryData> {
+  const match = findOperation(spec, operationId);
+  if (!match) {
+    throw new Error(`OpenAPI operation not found: ${operationId}`);
+  }
+
+  const requestBody = resolveRequestBody(spec, match.operation.requestBody);
+  const title = match.operation.summary?.trim() || `${match.method.toUpperCase()} ${match.path}`;
+
+  return {
+    id: operationId,
+    data: {
+      title,
+      summary: match.operation.summary?.trim(),
+      description: match.operation.description?.trim(),
+      method: match.method.toUpperCase(),
+      path: match.path,
+      tags: match.operation.tags,
+      parameters: collectParameters(spec, match.pathItem, match.operation),
+      requestBody: requestBody
+        ? {
+            description: requestBody.description,
+            required: requestBody.required,
+            contents: collectMediaTypes(spec, requestBody.content),
+          }
+        : undefined,
+      responses: collectResponses(spec, match.operation.responses),
+      codeSamples: collectCodeSamples(match.operation),
+    },
+  };
+}

--- a/packages/converters/src/index.ts
+++ b/packages/converters/src/index.ts
@@ -1,3 +1,16 @@
+export {
+  apiReferenceConverter,
+  fromOpenAPI,
+  type ApiReferenceCodeSample,
+  type ApiReferenceConverterConfig,
+  type ApiReferenceEntryData,
+  type ApiReferenceField,
+  type ApiReferenceMediaType,
+  type ApiReferenceParameter,
+  type ApiReferenceRequestBody,
+  type ApiReferenceResponse,
+  type OpenAPIDocument,
+} from "./api-reference.js";
 export { blogConverter, type BlogConverterConfig, type BlogEntryData } from "./blog.js";
 export {
   caseStudyConverter,
@@ -60,6 +73,7 @@ export type {
 } from "./types.js";
 
 export const BUILT_IN_CONVERTERS = [
+  "api-reference",
   "blog",
   "case-study",
   "changelog",

--- a/packages/converters/test/converters.test.ts
+++ b/packages/converters/test/converters.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect } from "vitest";
 import {
+  apiReferenceConverter,
+  type OpenAPIDocument,
   blogConverter,
   caseStudyConverter,
   changelogConverter,
   compareConverter,
   docsConverter,
+  fromOpenAPI,
   featureConverter,
   glossaryConverter,
   integrationConverter,
@@ -16,8 +19,10 @@ import {
   videoConverter,
   BUILT_IN_CONVERTERS,
 } from "../src/index.js";
+import petstoreSpec from "./fixtures/petstore-openapi.js";
 
 const SITE = "https://acme.test";
+const PETSTORE_SPEC: OpenAPIDocument = petstoreSpec;
 
 describe("blogConverter", () => {
   const convert = blogConverter({ siteUrl: SITE });
@@ -610,9 +615,148 @@ describe("docsConverter", () => {
   });
 });
 
+describe("apiReferenceConverter", () => {
+  const convert = apiReferenceConverter({ siteUrl: SITE, basePath: "/api-reference" });
+
+  it("renders method, path, parameters, request body, responses, and code samples", () => {
+    const out = convert({
+      id: "create-pet",
+      data: {
+        title: "Create pet",
+        summary: "Create a new pet.",
+        description: "Creates a resource for a single pet.",
+        method: "POST",
+        path: "/pet",
+        tags: ["pet"],
+        parameters: [
+          {
+            name: "traceId",
+            in: "header",
+            type: "string",
+            required: false,
+            description: "Optional request trace identifier.",
+          },
+        ],
+        requestBody: {
+          description: "JSON payload for the pet.",
+          required: true,
+          contents: [
+            {
+              contentType: "application/json",
+              schema: "object",
+              fields: [
+                { name: "name", type: "string", required: true, description: "Pet name." },
+                { name: "status", type: "string enum(available, pending, sold)" },
+              ],
+            },
+          ],
+        },
+        responses: [
+          {
+            status: "200",
+            description: "Successful operation",
+            contents: [
+              {
+                contentType: "application/json",
+                schema: "object",
+                fields: [{ name: "id", type: "integer(int64)", description: "New pet id." }],
+              },
+            ],
+          },
+        ],
+        codeSamples: [
+          {
+            lang: "curl",
+            source:
+              "curl -X POST https://acme.test/pet -H \"Content-Type: application/json\" -d '{\"name\":\"doggie\"}'",
+          },
+        ],
+      },
+      body: "Use this endpoint when onboarding a new pet.",
+    });
+
+    expect(out).toContain("# Create pet");
+    expect(out).toContain("> Create a new pet.");
+    expect(out).toContain("- **Method**: `POST`");
+    expect(out).toContain("- **Path**: `/pet`");
+    expect(out).toContain("- **URL**: https://acme.test/api-reference/create-pet");
+    expect(out).toContain("| `traceId` | `header` | `string` | no | Optional request trace identifier. |");
+    expect(out).toContain("## Request body");
+    expect(out).toContain("### `application/json`");
+    expect(out).toContain("| `name` | `string` | yes | Pet name. |");
+    expect(out).toContain("## Responses");
+    expect(out).toContain("### `200`");
+    expect(out).toContain("## Code samples");
+    expect(out).toContain("```bash");
+    expect(out).toContain("Use this endpoint when onboarding a new pet.");
+  });
+});
+
+describe("fromOpenAPI", () => {
+  it("projects a Petstore operation with request body, nested schema fields, and code samples", () => {
+    const entry = fromOpenAPI(PETSTORE_SPEC, "addPet");
+    expect(entry.id).toBe("addPet");
+    expect(entry.data.title).toBe("Add a new pet to the store");
+    expect(entry.data.method).toBe("POST");
+    expect(entry.data.path).toBe("/pet");
+    expect(entry.data.tags).toEqual(["pet"]);
+    expect(entry.data.requestBody?.required).toBe(true);
+    expect(entry.data.requestBody?.contents[0]?.contentType).toBe("application/json");
+    expect(entry.data.requestBody?.contents[0]?.schema).toBe("object");
+    expect(entry.data.requestBody?.contents[0]?.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "name", type: "string", required: true }),
+        expect.objectContaining({
+          name: "status",
+          type: "string enum(available, pending, sold)",
+        }),
+        expect.objectContaining({ name: "category", type: "object" }),
+        expect.objectContaining({ name: "category.id", type: "integer(int64)" }),
+        expect.objectContaining({ name: "tags", type: "array<object>" }),
+        expect.objectContaining({ name: "tags[].name", type: "string" }),
+      ]),
+    );
+    expect(entry.data.responses[0]?.contents?.[0]?.fields).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "photoUrls", type: "array<string>" })]),
+    );
+    expect(entry.data.codeSamples).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ lang: "curl" }),
+        expect.objectContaining({ lang: "javascript", label: "JavaScript" }),
+      ]),
+    );
+  });
+
+  it("projects path parameters from a Petstore endpoint", () => {
+    const entry = fromOpenAPI(PETSTORE_SPEC, "getPetById");
+    expect(entry.data.parameters).toEqual([
+      {
+        name: "petId",
+        in: "path",
+        type: "integer(int64)",
+        required: true,
+        description: "ID of pet to return",
+      },
+    ]);
+    expect(entry.data.responses[1]).toEqual(
+      expect.objectContaining({
+        status: "404",
+        description: "Pet not found",
+      }),
+    );
+  });
+
+  it("throws when the requested operation is missing", () => {
+    expect(() => fromOpenAPI(PETSTORE_SPEC, "missingOperation")).toThrow(
+      "OpenAPI operation not found: missingOperation",
+    );
+  });
+});
+
 describe("BUILT_IN_CONVERTERS export", () => {
-  it("lists all 13 generic built-in names in alphabetical order", () => {
+  it("lists all 14 generic built-in names in alphabetical order", () => {
     expect(BUILT_IN_CONVERTERS).toEqual([
+      "api-reference",
       "blog",
       "case-study",
       "changelog",

--- a/packages/converters/test/fixtures/petstore-openapi.ts
+++ b/packages/converters/test/fixtures/petstore-openapi.ts
@@ -1,0 +1,156 @@
+import type { OpenAPIDocument } from "../../src/api-reference.js";
+
+const petstoreSpec = {
+  openapi: "3.1.0",
+  info: {
+    title: "Petstore",
+    version: "1.0.0",
+  },
+  paths: {
+    "/pet": {
+      post: {
+        operationId: "addPet",
+        summary: "Add a new pet to the store",
+        description: "Creates a pet resource from the supplied JSON payload.",
+        tags: ["pet"],
+        requestBody: {
+          description: "Pet payload to create.",
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/Pet",
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Successful operation",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Pet",
+                },
+              },
+            },
+          },
+          "405": {
+            description: "Invalid input",
+          },
+        },
+        "x-codeSamples": [
+          {
+            lang: "curl",
+            label: "curl",
+            source:
+              "curl -X POST https://petstore.example.com/pet -H \"Content-Type: application/json\" -d '{\"name\":\"doggie\"}'",
+          },
+          {
+            lang: "javascript",
+            label: "JavaScript",
+            source:
+              "await fetch(\"https://petstore.example.com/pet\", { method: \"POST\", headers: { \"Content-Type\": \"application/json\" }, body: JSON.stringify({ name: \"doggie\" }) });",
+          },
+        ],
+      },
+    },
+    "/pet/{petId}": {
+      get: {
+        operationId: "getPetById",
+        summary: "Find pet by ID",
+        description: "Returns a single pet.",
+        tags: ["pet"],
+        parameters: [
+          {
+            name: "petId",
+            in: "path",
+            description: "ID of pet to return",
+            required: true,
+            schema: {
+              type: "integer",
+              format: "int64",
+            },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "Successful operation",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Pet",
+                },
+              },
+            },
+          },
+          "404": {
+            description: "Pet not found",
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      Pet: {
+        type: "object",
+        required: ["name", "photoUrls"],
+        properties: {
+          id: {
+            type: "integer",
+            format: "int64",
+            description: "Unique pet identifier.",
+          },
+          name: {
+            type: "string",
+            description: "Display name for the pet.",
+          },
+          status: {
+            type: "string",
+            description: "Availability state.",
+            enum: ["available", "pending", "sold"],
+          },
+          photoUrls: {
+            type: "array",
+            description: "Photo URLs for the pet.",
+            items: {
+              type: "string",
+            },
+          },
+          category: {
+            type: "object",
+            description: "Grouping information.",
+            properties: {
+              id: {
+                type: "integer",
+                format: "int64",
+              },
+              name: {
+                type: "string",
+              },
+            },
+          },
+          tags: {
+            type: "array",
+            description: "Tags attached to the pet.",
+            items: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "integer",
+                  format: "int64",
+                },
+                name: {
+                  type: "string",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} satisfies OpenAPIDocument;
+
+export default petstoreSpec;


### PR DESCRIPTION
## Summary

Adds a built-in API reference converter to `@dualmark/converters`, including an OpenAPI projection helper with zero new runtime dependencies.

## Changes

- add `apiReferenceConverter()` for rendering API reference entries with parameters, request/response schema sections, and code samples
- add `fromOpenAPI(spec, operationId)` to project OpenAPI 3.x operations into the converter input shape with local component ref support
- add Petstore-based tests and fixture coverage for OpenAPI projection, missing-operation handling, and markdown output
- update docs, package metadata, counts, and the built-in converter list to include `api-reference`
- add a changeset for the new converter capability

## Type

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change
- [ ] Spec change (requires bump in `AEO_SPEC_VERSION`)
- [ ] Docs / examples / tooling only

## Verification

- [x] `bun run build` passes
- [x] `bun run test` passes
- [x] `bun run typecheck` passes
- [ ] If touching examples: ran `dualmark verify` against the example end-to-end
- [ ] If touching `/spec/`: ran `bun run --filter dualmark-docs sync-spec` and committed the mirror

## Changeset

- [x] Added a changeset (`bun run changeset`) for any package with a user-visible change

Fixes #14.
