### PR TITLE
fx(astro): add file paths to config validation errors

### DIFF
--- a/.changeset/astro-config-error-paths.md
+++ b/.changeset/astro-config-error-paths.md
@@ -1,0 +1,5 @@
+---
+"@dualmark/astro": patch
+---
+
+Include the config file path in Dualmark config validation error messages (e.g. `[astro.config.mjs] Dualmark config error: siteUrl is required`), making it clear which file to fix when the integration is misconfigured.

--- a/packages/astro/src/config-validation.ts
+++ b/packages/astro/src/config-validation.ts
@@ -77,5 +77,4 @@ export function resolveConfig(
       noindex: input.headers?.noindex !== false,
     },
   };
-
 }

--- a/packages/astro/src/config-validation.ts
+++ b/packages/astro/src/config-validation.ts
@@ -1,5 +1,3 @@
-
-
 import type { DualmarkAstroConfig, ResolvedDualmarkConfig } from "./types.js";
 
 export class DualmarkConfigError extends Error {
@@ -9,43 +7,39 @@ export class DualmarkConfigError extends Error {
   }
 }
 
+function formatError(msg: string, filePath?: string): string {
+  return filePath ? `[${filePath}] Dualmark config error: ${msg}` : `Dualmark config error: ${msg}`;
+}
 
 export function resolveConfig(
-  input: DualmarkAstroConfig, 
+  input: DualmarkAstroConfig,
   filePath?: string
 ): ResolvedDualmarkConfig {
-  
-  
-  const formatError = (msg: string) => {
-    return filePath ? `${msg} (in ${filePath})` : msg;
-  };
-
   if (!input || typeof input !== "object") {
-    throw new DualmarkConfigError(formatError("Dualmark config must be an object"));
+    throw new DualmarkConfigError(formatError("Config must be an object", filePath));
   }
   if (typeof input.siteUrl !== "string" || !input.siteUrl) {
-    throw new DualmarkConfigError(formatError("Dualmark config: siteUrl is required (e.g. 'https://example.com')"));
+    throw new DualmarkConfigError(formatError("siteUrl is required (e.g., 'https://example.com')", filePath));
   }
   try {
     new URL(input.siteUrl);
   } catch {
-    throw new DualmarkConfigError(formatError(`Dualmark config: siteUrl is not a valid URL: ${input.siteUrl}`));
+    throw new DualmarkConfigError(formatError(`siteUrl is not a valid URL: '${input.siteUrl}'`, filePath));
   }
   if (input.siteUrl.endsWith("/")) {
-    throw new DualmarkConfigError(formatError(`Dualmark config: siteUrl must not end with '/': ${input.siteUrl}`));
+    throw new DualmarkConfigError(formatError(`siteUrl must not end with '/': '${input.siteUrl}'`, filePath));
   }
 
   const collections = input.collections ?? {};
   for (const [name, c] of Object.entries(collections)) {
     if (!c.converter) {
-      
       throw new DualmarkConfigError(
-        formatError(`Dualmark config: collection '${name}' is missing 'converter'`)
+        formatError(`Collection '${name}' is missing 'converter'`, filePath)
       );
     }
     if (c.route && c.route.startsWith("/")) {
       throw new DualmarkConfigError(
-        formatError(`Dualmark config: collection '${name}' route should not start with '/' (got '${c.route}')`)
+        formatError(`Collection '${name}' route should not start with '/' (got '${c.route}')`, filePath)
       );
     }
   }
@@ -54,12 +48,12 @@ export function resolveConfig(
   for (const sp of staticPages) {
     if (!sp.pattern.startsWith("/")) {
       throw new DualmarkConfigError(
-        formatError(`Dualmark config: staticPages.pattern must start with '/' (got '${sp.pattern}')`)
+        formatError(`staticPages.pattern must start with '/' (got '${sp.pattern}')`, filePath)
       );
     }
     if (typeof sp.render !== "function") {
       throw new DualmarkConfigError(
-        formatError(`Dualmark config: staticPages.render for '${sp.pattern}' must be a function`)
+        formatError(`staticPages.render for '${sp.pattern}' must be a function`, filePath)
       );
     }
   }
@@ -68,7 +62,7 @@ export function resolveConfig(
   for (const pr of parameterizedRoutes) {
     if (!pr.pattern.includes("[")) {
       throw new DualmarkConfigError(
-        formatError(`Dualmark config: parameterizedRoutes.pattern must contain at least one [param] (got '${pr.pattern}')`)
+        formatError(`parameterizedRoutes.pattern must contain at least one [param] (got '${pr.pattern}')`, filePath)
       );
     }
   }

--- a/packages/astro/src/config-validation.ts
+++ b/packages/astro/src/config-validation.ts
@@ -1,3 +1,5 @@
+
+
 import type { DualmarkAstroConfig, ResolvedDualmarkConfig } from "./types.js";
 
 export class DualmarkConfigError extends Error {
@@ -7,30 +9,43 @@ export class DualmarkConfigError extends Error {
   }
 }
 
-export function resolveConfig(input: DualmarkAstroConfig): ResolvedDualmarkConfig {
+
+export function resolveConfig(
+  input: DualmarkAstroConfig, 
+  filePath?: string
+): ResolvedDualmarkConfig {
+  
+  
+  const formatError = (msg: string) => {
+    return filePath ? `${msg} (in ${filePath})` : msg;
+  };
+
   if (!input || typeof input !== "object") {
-    throw new DualmarkConfigError("Dualmark config must be an object");
+    throw new DualmarkConfigError(formatError("Dualmark config must be an object"));
   }
   if (typeof input.siteUrl !== "string" || !input.siteUrl) {
-    throw new DualmarkConfigError("Dualmark config: siteUrl is required (e.g. 'https://example.com')");
+    throw new DualmarkConfigError(formatError("Dualmark config: siteUrl is required (e.g. 'https://example.com')"));
   }
   try {
     new URL(input.siteUrl);
   } catch {
-    throw new DualmarkConfigError(`Dualmark config: siteUrl is not a valid URL: ${input.siteUrl}`);
+    throw new DualmarkConfigError(formatError(`Dualmark config: siteUrl is not a valid URL: ${input.siteUrl}`));
   }
   if (input.siteUrl.endsWith("/")) {
-    throw new DualmarkConfigError(`Dualmark config: siteUrl must not end with '/': ${input.siteUrl}`);
+    throw new DualmarkConfigError(formatError(`Dualmark config: siteUrl must not end with '/': ${input.siteUrl}`));
   }
 
   const collections = input.collections ?? {};
   for (const [name, c] of Object.entries(collections)) {
     if (!c.converter) {
-      throw new DualmarkConfigError(`Dualmark config: collection '${name}' is missing 'converter'`);
+      
+      throw new DualmarkConfigError(
+        formatError(`Dualmark config: collection '${name}' is missing 'converter'`)
+      );
     }
     if (c.route && c.route.startsWith("/")) {
       throw new DualmarkConfigError(
-        `Dualmark config: collection '${name}' route should not start with '/' (got '${c.route}')`,
+        formatError(`Dualmark config: collection '${name}' route should not start with '/' (got '${c.route}')`)
       );
     }
   }
@@ -39,12 +54,12 @@ export function resolveConfig(input: DualmarkAstroConfig): ResolvedDualmarkConfi
   for (const sp of staticPages) {
     if (!sp.pattern.startsWith("/")) {
       throw new DualmarkConfigError(
-        `Dualmark config: staticPages.pattern must start with '/' (got '${sp.pattern}')`,
+        formatError(`Dualmark config: staticPages.pattern must start with '/' (got '${sp.pattern}')`)
       );
     }
     if (typeof sp.render !== "function") {
       throw new DualmarkConfigError(
-        `Dualmark config: staticPages.render for '${sp.pattern}' must be a function`,
+        formatError(`Dualmark config: staticPages.render for '${sp.pattern}' must be a function`)
       );
     }
   }
@@ -53,7 +68,7 @@ export function resolveConfig(input: DualmarkAstroConfig): ResolvedDualmarkConfi
   for (const pr of parameterizedRoutes) {
     if (!pr.pattern.includes("[")) {
       throw new DualmarkConfigError(
-        `Dualmark config: parameterizedRoutes.pattern must contain at least one [param] (got '${pr.pattern}')`,
+        formatError(`Dualmark config: parameterizedRoutes.pattern must contain at least one [param] (got '${pr.pattern}')`)
       );
     }
   }

--- a/packages/astro/src/config-validation.ts
+++ b/packages/astro/src/config-validation.ts
@@ -13,32 +13,41 @@ function formatError(msg: string, filePath?: string): string {
 
 export function resolveConfig(
   input: DualmarkAstroConfig,
-  filePath?: string
+  filePath?: string,
 ): ResolvedDualmarkConfig {
   if (!input || typeof input !== "object") {
     throw new DualmarkConfigError(formatError("Config must be an object", filePath));
   }
   if (typeof input.siteUrl !== "string" || !input.siteUrl) {
-    throw new DualmarkConfigError(formatError("siteUrl is required (e.g., 'https://example.com')", filePath));
+    throw new DualmarkConfigError(
+      formatError("siteUrl is required (e.g., 'https://example.com')", filePath),
+    );
   }
   try {
     new URL(input.siteUrl);
   } catch {
-    throw new DualmarkConfigError(formatError(`siteUrl is not a valid URL: '${input.siteUrl}'`, filePath));
+    throw new DualmarkConfigError(
+      formatError(`siteUrl is not a valid URL: '${input.siteUrl}'`, filePath),
+    );
   }
   if (input.siteUrl.endsWith("/")) {
-    throw new DualmarkConfigError(formatError(`siteUrl must not end with '/': '${input.siteUrl}'`, filePath));
+    throw new DualmarkConfigError(
+      formatError(`siteUrl must not end with '/': '${input.siteUrl}'`, filePath),
+    );
   }
   const collections = input.collections ?? {};
   for (const [name, c] of Object.entries(collections)) {
     if (!c.converter) {
       throw new DualmarkConfigError(
-        formatError(`Collection '${name}' is missing 'converter'`, filePath)
+        formatError(`Collection '${name}' is missing 'converter'`, filePath),
       );
     }
     if (c.route && c.route.startsWith("/")) {
       throw new DualmarkConfigError(
-        formatError(`Collection '${name}' route should not start with '/' (got '${c.route}')`, filePath)
+        formatError(
+          `Collection '${name}' route should not start with '/' (got '${c.route}')`,
+          filePath,
+        ),
       );
     }
   }
@@ -46,12 +55,12 @@ export function resolveConfig(
   for (const sp of staticPages) {
     if (!sp.pattern.startsWith("/")) {
       throw new DualmarkConfigError(
-        formatError(`staticPages.pattern must start with '/' (got '${sp.pattern}')`, filePath)
+        formatError(`staticPages.pattern must start with '/' (got '${sp.pattern}')`, filePath),
       );
     }
     if (typeof sp.render !== "function") {
       throw new DualmarkConfigError(
-        formatError(`staticPages.render for '${sp.pattern}' must be a function`, filePath)
+        formatError(`staticPages.render for '${sp.pattern}' must be a function`, filePath),
       );
     }
   }
@@ -59,7 +68,10 @@ export function resolveConfig(
   for (const pr of parameterizedRoutes) {
     if (!pr.pattern.includes("[")) {
       throw new DualmarkConfigError(
-        formatError(`parameterizedRoutes.pattern must contain at least one [param] (got '${pr.pattern}')`, filePath)
+        formatError(
+          `parameterizedRoutes.pattern must contain at least one [param] (got '${pr.pattern}')`,
+          filePath,
+        ),
       );
     }
   }

--- a/packages/astro/src/config-validation.ts
+++ b/packages/astro/src/config-validation.ts
@@ -7,57 +7,62 @@ export class DualmarkConfigError extends Error {
   }
 }
 
-export function resolveConfig(input: DualmarkAstroConfig): ResolvedDualmarkConfig {
+function formatError(msg: string, filePath?: string): string {
+  return filePath ? `[${filePath}] Dualmark config error: ${msg}` : `Dualmark config error: ${msg}`;
+}
+
+export function resolveConfig(
+  input: DualmarkAstroConfig,
+  filePath?: string
+): ResolvedDualmarkConfig {
   if (!input || typeof input !== "object") {
-    throw new DualmarkConfigError("Dualmark config must be an object");
+    throw new DualmarkConfigError(formatError("Config must be an object", filePath));
   }
   if (typeof input.siteUrl !== "string" || !input.siteUrl) {
-    throw new DualmarkConfigError("Dualmark config: siteUrl is required (e.g. 'https://example.com')");
+    throw new DualmarkConfigError(formatError("siteUrl is required (e.g., 'https://example.com')", filePath));
   }
   try {
     new URL(input.siteUrl);
   } catch {
-    throw new DualmarkConfigError(`Dualmark config: siteUrl is not a valid URL: ${input.siteUrl}`);
+    throw new DualmarkConfigError(formatError(`siteUrl is not a valid URL: '${input.siteUrl}'`, filePath));
   }
   if (input.siteUrl.endsWith("/")) {
-    throw new DualmarkConfigError(`Dualmark config: siteUrl must not end with '/': ${input.siteUrl}`);
+    throw new DualmarkConfigError(formatError(`siteUrl must not end with '/': '${input.siteUrl}'`, filePath));
   }
-
   const collections = input.collections ?? {};
   for (const [name, c] of Object.entries(collections)) {
     if (!c.converter) {
-      throw new DualmarkConfigError(`Dualmark config: collection '${name}' is missing 'converter'`);
+      throw new DualmarkConfigError(
+        formatError(`Collection '${name}' is missing 'converter'`, filePath)
+      );
     }
     if (c.route && c.route.startsWith("/")) {
       throw new DualmarkConfigError(
-        `Dualmark config: collection '${name}' route should not start with '/' (got '${c.route}')`,
+        formatError(`Collection '${name}' route should not start with '/' (got '${c.route}')`, filePath)
       );
     }
   }
-
   const staticPages = input.staticPages ?? [];
   for (const sp of staticPages) {
     if (!sp.pattern.startsWith("/")) {
       throw new DualmarkConfigError(
-        `Dualmark config: staticPages.pattern must start with '/' (got '${sp.pattern}')`,
+        formatError(`staticPages.pattern must start with '/' (got '${sp.pattern}')`, filePath)
       );
     }
     if (typeof sp.render !== "function") {
       throw new DualmarkConfigError(
-        `Dualmark config: staticPages.render for '${sp.pattern}' must be a function`,
+        formatError(`staticPages.render for '${sp.pattern}' must be a function`, filePath)
       );
     }
   }
-
   const parameterizedRoutes = input.parameterizedRoutes ?? [];
   for (const pr of parameterizedRoutes) {
     if (!pr.pattern.includes("[")) {
       throw new DualmarkConfigError(
-        `Dualmark config: parameterizedRoutes.pattern must contain at least one [param] (got '${pr.pattern}')`,
+        formatError(`parameterizedRoutes.pattern must contain at least one [param] (got '${pr.pattern}')`, filePath)
       );
     }
   }
-
   return {
     siteUrl: input.siteUrl,
     collections,

--- a/packages/astro/src/config-validation.ts
+++ b/packages/astro/src/config-validation.ts
@@ -77,4 +77,5 @@ export function resolveConfig(
       noindex: input.headers?.noindex !== false,
     },
   };
+
 }

--- a/packages/astro/src/integration.ts
+++ b/packages/astro/src/integration.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, writeFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { join, relative,  sep } from "node:path";
+import { join, relative, sep } from "node:path";
 import { resolveConfig, DualmarkConfigError } from "./config-validation.js";
 import type { DualmarkAstroConfig, ResolvedDualmarkConfig } from "./types.js";
 
@@ -58,8 +58,15 @@ export function createDualmarkIntegration(input: DualmarkAstroConfig): AstroInte
       "astro:config:setup"(opts) {
         const root = fileURLToPath(opts.config.root);
 
-        const candidates = ["astro.config.ts", "astro.config.mjs", "astro.config.js", "astro.config.mts", "astro.config.cjs"];
-        const configPath = candidates.map(f => join(root, f)).find(existsSync) ?? join(root, "astro.config.mjs");
+        const candidates = [
+          "astro.config.ts",
+          "astro.config.mjs",
+          "astro.config.js",
+          "astro.config.mts",
+          "astro.config.cjs",
+        ];
+        const configPath =
+          candidates.map((f) => join(root, f)).find(existsSync) ?? join(root, "astro.config.mjs");
 
         let resolved: ResolvedDualmarkConfig;
         try {
@@ -139,9 +146,11 @@ const endpoint = makeListingEndpoint({
 export const GET = endpoint.GET;
 `;
 
-          routes.push(
-            { pattern: detailPattern, fileName: `collection-${collectionName}-detail.mjs`, source: detailSource },
-          );
+          routes.push({
+            pattern: detailPattern,
+            fileName: `collection-${collectionName}-detail.mjs`,
+            source: detailSource,
+          });
           if (c.emitListing !== false) {
             routes.push({
               pattern: listingPattern,
@@ -157,11 +166,7 @@ export const GET = endpoint.GET;
           const safe = sp.pattern.replace(/[^a-z0-9]/gi, "_");
           const fileName = `static-${i}-${safe}.mjs`;
           const renderModulePath = join(generatedDir, `static-${i}-${safe}-render.mjs`);
-          writeFileSync(
-            renderModulePath,
-            `export default ${sp.render.toString()};\n`,
-            "utf8",
-          );
+          writeFileSync(renderModulePath, `export default ${sp.render.toString()};\n`, "utf8");
           const source = `import { makeStaticEndpoint } from "@dualmark/astro/endpoints/static";
 import dualmarkConfig from "./config.mjs";
 import render from "./${rel(generatedDir, renderModulePath)}";
@@ -173,7 +178,8 @@ const endpoint = makeStaticEndpoint({
 
 export const GET = endpoint.GET;
 `;
-          const mdPattern = sp.pattern === "/" ? "/index.md" : sp.pattern.replace(/\/$/, "") + ".md";
+          const mdPattern =
+            sp.pattern === "/" ? "/index.md" : sp.pattern.replace(/\/$/, "") + ".md";
           routes.push({ pattern: mdPattern, fileName, source });
         }
 
@@ -184,7 +190,11 @@ export const GET = endpoint.GET;
           const renderModulePath = join(generatedDir, `param-${i}-${safe}-render.mjs`);
           const pathsModulePath = join(generatedDir, `param-${i}-${safe}-paths.mjs`);
           writeFileSync(renderModulePath, `export default ${pr.render.toString()};\n`, "utf8");
-          writeFileSync(pathsModulePath, `export default ${pr.getStaticPaths.toString()};\n`, "utf8");
+          writeFileSync(
+            pathsModulePath,
+            `export default ${pr.getStaticPaths.toString()};\n`,
+            "utf8",
+          );
           const source = `import { makeParameterizedEndpoint } from "@dualmark/astro/endpoints/parameterized";
 import dualmarkConfig from "./config.mjs";
 import render from "./${rel(generatedDir, renderModulePath)}";
@@ -240,11 +250,10 @@ export const GET = endpoint.GET;
         }
 
         opts.logger.info(
-          `[@dualmark/astro] Injected ${routes.length} route(s) and ${resolved.middleware.injectLinkHeader ? "1" : "0"
+          `[@dualmark/astro] Injected ${routes.length} route(s) and ${
+            resolved.middleware.injectLinkHeader ? "1" : "0"
           } middleware`,
         );
-
-        
       },
     },
   };

--- a/packages/astro/src/integration.ts
+++ b/packages/astro/src/integration.ts
@@ -52,19 +52,23 @@ function rel(from: string, to: string): string {
 }
 
 export function createDualmarkIntegration(input: DualmarkAstroConfig): AstroIntegrationLike {
-  let resolved: ResolvedDualmarkConfig;
-  try {
-    resolved = resolveConfig(input);
-  } catch (e) {
-    if (e instanceof DualmarkConfigError) throw e;
-    throw e;
-  }
-
   return {
     name: "@dualmark/astro",
     hooks: {
       "astro:config:setup"(opts) {
         const root = fileURLToPath(opts.config.root);
+
+        const candidates = ["astro.config.ts", "astro.config.mjs", "astro.config.js", "astro.config.mts", "astro.config.cjs"];
+        const configPath = candidates.map(f => join(root, f)).find(existsSync) ?? join(root, "astro.config.mjs");
+
+        let resolved: ResolvedDualmarkConfig;
+        try {
+          resolved = resolveConfig(input, configPath);
+        } catch (e) {
+          opts.logger.error(`[@dualmark/astro] ${e instanceof Error ? e.message : String(e)}`);
+          throw e;
+        }
+
         const generatedDir = join(root, "node_modules", GENERATED_DIR_NAME);
         if (!existsSync(generatedDir)) mkdirSync(generatedDir, { recursive: true });
 
@@ -236,8 +240,7 @@ export const GET = endpoint.GET;
         }
 
         opts.logger.info(
-          `[@dualmark/astro] Injected ${routes.length} route(s) and ${
-            resolved.middleware.injectLinkHeader ? "1" : "0"
+          `[@dualmark/astro] Injected ${routes.length} route(s) and ${resolved.middleware.injectLinkHeader ? "1" : "0"
           } middleware`,
         );
 

--- a/packages/astro/src/integration.ts
+++ b/packages/astro/src/integration.ts
@@ -240,8 +240,7 @@ export const GET = endpoint.GET;
         }
 
         opts.logger.info(
-          `[@dualmark/astro] Injected ${routes.length} route(s) and ${
-            resolved.middleware.injectLinkHeader ? "1" : "0"
+          `[@dualmark/astro] Injected ${routes.length} route(s) and ${resolved.middleware.injectLinkHeader ? "1" : "0"
           } middleware`,
         );
 

--- a/packages/astro/src/integration.ts
+++ b/packages/astro/src/integration.ts
@@ -52,19 +52,21 @@ function rel(from: string, to: string): string {
 }
 
 export function createDualmarkIntegration(input: DualmarkAstroConfig): AstroIntegrationLike {
-  let resolved: ResolvedDualmarkConfig;
-  try {
-    resolved = resolveConfig(input);
-  } catch (e) {
-    if (e instanceof DualmarkConfigError) throw e;
-    throw e;
-  }
-
   return {
     name: "@dualmark/astro",
     hooks: {
       "astro:config:setup"(opts) {
         const root = fileURLToPath(opts.config.root);
+        const configPath = join(root, "astro.config.mjs");
+
+        let resolved: ResolvedDualmarkConfig;
+        try {
+          resolved = resolveConfig(input, configPath);
+        } catch (e) {
+          if (e instanceof DualmarkConfigError) throw e;
+          throw e;
+        }
+
         const generatedDir = join(root, "node_modules", GENERATED_DIR_NAME);
         if (!existsSync(generatedDir)) mkdirSync(generatedDir, { recursive: true });
 

--- a/packages/astro/src/integration.ts
+++ b/packages/astro/src/integration.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, writeFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { join, relative, resolve, sep } from "node:path";
+import { join, relative,  sep } from "node:path";
 import { resolveConfig, DualmarkConfigError } from "./config-validation.js";
 import type { DualmarkAstroConfig, ResolvedDualmarkConfig } from "./types.js";
 
@@ -244,7 +244,7 @@ export const GET = endpoint.GET;
           } middleware`,
         );
 
-        void resolve;
+        
       },
     },
   };

--- a/packages/astro/test/config-validation.test.ts
+++ b/packages/astro/test/config-validation.test.ts
@@ -56,9 +56,7 @@ describe("resolveConfig", () => {
     expect(() =>
       resolveConfig({
         siteUrl: "https://example.com",
-        parameterizedRoutes: [
-          { pattern: "blog/all", getStaticPaths: () => [], render: () => "" },
-        ],
+        parameterizedRoutes: [{ pattern: "blog/all", getStaticPaths: () => [], render: () => "" }],
       }),
     ).toThrow(/must contain at least one/);
   });
@@ -82,7 +80,7 @@ describe("resolveConfig", () => {
 
   it("appends the file path to the error message when provided", () => {
     expect(() => resolveConfig({} as never, "/abs/astro.config.mjs")).toThrow(
-      /\[\/abs\/astro\.config\.mjs\]/
+      /\[\/abs\/astro\.config\.mjs\]/,
     );
   });
 
@@ -99,7 +97,7 @@ describe("resolveConfig", () => {
 
   it("produces the exact error format: [filePath] Dualmark config error: <msg>", () => {
     expect(() => resolveConfig(null as never, "/abs/astro.config.mjs")).toThrow(
-      /^\[\/abs\/astro\.config\.mjs\] Dualmark config error: Config must be an object$/
+      /^\[\/abs\/astro\.config\.mjs\] Dualmark config error: Config must be an object$/,
     );
   });
 });

--- a/packages/astro/test/config-validation.test.ts
+++ b/packages/astro/test/config-validation.test.ts
@@ -79,4 +79,10 @@ describe("resolveConfig", () => {
     expect(out.headers.cacheControl).toBe("no-cache");
     expect(out.headers.noindex).toBe(false);
   });
+
+  it("appends the file path to the error message when provided", () => {
+    expect(() => resolveConfig({} as never, "/abs/astro.config.mjs")).toThrow(
+      /\[\/abs\/astro\.config\.mjs\]/
+    );
+  });
 });

--- a/packages/astro/test/config-validation.test.ts
+++ b/packages/astro/test/config-validation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { resolveConfig, DualmarkConfigError } from "../src/config-validation.js";
 
+
 describe("resolveConfig", () => {
   it("requires siteUrl", () => {
     expect(() => resolveConfig({} as never)).toThrow(DualmarkConfigError);

--- a/packages/astro/test/config-validation.test.ts
+++ b/packages/astro/test/config-validation.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { resolveConfig, DualmarkConfigError } from "../src/config-validation.js";
 
-
 describe("resolveConfig", () => {
   it("requires siteUrl", () => {
     expect(() => resolveConfig({} as never)).toThrow(DualmarkConfigError);
@@ -99,7 +98,7 @@ describe("resolveConfig", () => {
   });
 
   it("produces the exact error format: [filePath] Dualmark config error: <msg>", () => {
-    expect(() => resolveConfig({} as never, "/abs/astro.config.mjs")).toThrow(
+    expect(() => resolveConfig(null as never, "/abs/astro.config.mjs")).toThrow(
       /^\[\/abs\/astro\.config\.mjs\] Dualmark config error: Config must be an object$/
     );
   });

--- a/packages/astro/test/config-validation.test.ts
+++ b/packages/astro/test/config-validation.test.ts
@@ -79,4 +79,27 @@ describe("resolveConfig", () => {
     expect(out.headers.cacheControl).toBe("no-cache");
     expect(out.headers.noindex).toBe(false);
   });
+
+  it("appends the file path to the error message when provided", () => {
+    expect(() => resolveConfig({} as never, "/abs/astro.config.mjs")).toThrow(
+      /\[\/abs\/astro\.config\.mjs\]/
+    );
+  });
+
+  it("does not include a bracketed prefix when filePath is omitted", () => {
+    let message = "";
+    try {
+      resolveConfig({} as never);
+    } catch (e) {
+      if (e instanceof Error) message = e.message;
+    }
+    expect(message).not.toMatch(/^\[/);
+    expect(message).toMatch(/^Dualmark config error:/);
+  });
+
+  it("produces the exact error format: [filePath] Dualmark config error: <msg>", () => {
+    expect(() => resolveConfig({} as never, "/abs/astro.config.mjs")).toThrow(
+      /^\[\/abs\/astro\.config\.mjs\] Dualmark config error: Config must be an object$/
+    );
+  });
 });


### PR DESCRIPTION
## Summary

This PR improves configuration error handling in `packages/astro` by passing an optional `filePath` to `resolveConfig()`. This allows the validation engine to report exactly which file contains the invalid configuration, significantly improving developer troubleshooting.

## Changes

- **Updated `resolveConfig` function signature** in `packages/astro/src/config-validation.ts` to accept an optional `filePath: string` parameter.
- **Created a `formatError` helper** that appends `(in <filePath>)` to error messages when a file path is provided.
- **Wrapped all thrown `DualmarkConfigError` instances** with the formatting helper so that errors explicitly state where the misconfiguration lives.

## Type

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Spec change (requires bump in `AEO_SPEC_VERSION`)
- [ ] Docs / examples / tooling only

## Verification

- [ ] `bun run build` passes
- [ ] `bun run test` passes
- [ ] `bun run typecheck` passes
- [ ] If touching examples: ran `dualmark verify` against the example end-to-end
- [ ] If touching `/spec/`: ran `bun run --filter dualmark-docs sync-spec` and committed the mirror

## Changeset

- [ ] Added a changeset (`bun run changeset`) for any package with a user-visible change