### PR TITLE
feat(vercel): add @dualmark/vercel edge adapter (closes #8)

### DIFF
--- a/.changeset/vercel-edge-adapter.md
+++ b/.changeset/vercel-edge-adapter.md
@@ -1,0 +1,5 @@
+---
+"@dualmark/vercel": minor
+---
+
+Add `@dualmark/vercel` — Vercel Edge Middleware adapter for the Dualmark AEO framework.

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -68,6 +68,22 @@ jobs:
           node ../../packages/cli/dist/cli.js verify http://localhost:3000/posts/hello
           kill $NEXT_PID
 
+  vercel-edge-full:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: bunx turbo run build --filter='@dualmark/*'
+      - name: Run vercel-edge-full under next dev
+        working-directory: examples/vercel-edge-full
+        run: |
+          ./node_modules/.bin/next dev --port 3001 &
+          NEXT_PID=$!
+          sleep 15
+          node ../../packages/cli/dist/cli.js verify http://localhost:3001/posts/hello
+          kill $NEXT_PID
+
   sveltekit-blog:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Three conformance levels — **Basic** (60%), **Standard** (80%), **Advanced** (
 | [`@dualmark/nextjs`](./packages/nextjs) | `npm i @dualmark/nextjs` | 15 KB | Next.js App Router adapter. `withDualmark()`, `createDualmarkMiddleware()`, `createDualmarkRouteHandler()`, `createLlmsTxtHandler()`. |
 | [`@dualmark/sveltekit`](./packages/sveltekit) | `npm i @dualmark/sveltekit` | 19 KB | SvelteKit adapter. Vite route generator, `createDualmarkHandle()`, generated `.md` endpoints, and `llms.txt`. |
 | [`@dualmark/cloudflare`](./packages/cloudflare) | `npm i @dualmark/cloudflare` | 9 KB | Workers edge adapter. Wraps any upstream Worker. Hooks for analytics + telemetry. |
+| [`@dualmark/vercel`](./packages/vercel) | `npm i @dualmark/vercel` | 9 KB | Vercel Edge Middleware adapter. `createAEOMiddleware()` wraps any upstream handler; serves pre-built `.md` with lifecycle hooks. |
 | [`@dualmark/deno`](./packages/deno) | `npm i @dualmark/deno` | 8 KB | Deno Deploy edge adapter. Wraps any Deno fetch handler. Lifecycle hooks scheduled on `info.completed`. |
 | [`@dualmark/cli`](./packages/cli) | `npm i -g @dualmark/cli` | 16 KB | `dualmark verify <url>`. Programmatic API too. |
 
@@ -321,7 +322,7 @@ bun run build && bun run test && bun run typecheck   # 368 tests across 8 packag
 We're building toward Dualmark being **the** AEO infrastructure for marketing sites — the same way Tailwind became the default for marketing CSS or Vercel for marketing hosting. The roadmap:
 
 - **More framework adapters**: Remix/React Router, Nuxt
-- **More edge adapters**: Vercel, Netlify, Fastly Compute, Deno Deploy
+- **More edge adapters**: Netlify, Fastly Compute
 - **More converters**: pricing tables, changelog, docs/API reference, status pages, integrations
 - **AEO Analytics**: a hosted dashboard on top of the `onAIRequest` hook, so marketing can see which bot reads which page, when
 - **Spec evolution toward AEO 1.1+** with structured data hints, per-section markdown anchors, and sitemap.md

--- a/apps/docs/content/docs/integrations/meta.json
+++ b/apps/docs/content/docs/integrations/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Integrations",
-  "pages": ["astro", "nextjs", "sveltekit", "cloudflare-workers", "deno", "manual"]
+  "pages": ["astro", "nextjs", "sveltekit", "cloudflare-workers", "vercel", "deno", "manual"]
 }

--- a/apps/docs/content/docs/integrations/vercel.mdx
+++ b/apps/docs/content/docs/integrations/vercel.mdx
@@ -1,0 +1,126 @@
+---
+title: Vercel Edge
+description: Wrap any upstream handler with createAEOMiddleware for edge negotiation on Vercel.
+---
+
+`@dualmark/vercel` is a Vercel Edge Middleware adapter. Drop it into `proxy.ts` (or `middleware.ts`), give it your upstream handler and a `fetchAsset` function, and it adds AI bot detection, markdown serving, header injection, and lifecycle hooks at the edge. It serves pre-built `.md` files — bring your own (a static export, a build step, or a framework that emits them), and the middleware negotiates which representation each visitor gets.
+
+## Install
+
+<Tabs items={["bun", "npm", "yarn"]}>
+<Tab value="bun">
+```bash
+bun add @dualmark/vercel @dualmark/core
+```
+</Tab>
+<Tab value="npm">
+```bash
+npm install @dualmark/vercel @dualmark/core
+```
+</Tab>
+<Tab value="yarn">
+```bash
+yarn add @dualmark/vercel @dualmark/core
+```
+</Tab>
+</Tabs>
+
+## Next.js (App Router)
+
+```ts title="proxy.ts"
+import { NextResponse } from "next/server";
+import { createAEOMiddleware } from "@dualmark/vercel";
+
+const middleware = createAEOMiddleware({
+  upstream: async () => NextResponse.next(),
+  fetchAsset: async (url, init) => fetch(url.toString(), init),
+  trailingSlash: "never",
+  enableLinkHeader: true,
+});
+
+export default middleware;
+
+export const config = {
+  matcher: ["/((?!_next/|favicon.ico).*)"],
+};
+```
+
+<Callout type="warn">
+  Your `fetchAsset` **must forward the `init` argument** (`fetch(url.toString(), init)`). The middleware sets an `x-dualmark-subrequest` header on its internal `.md` fetches; forwarding `init` lets the middleware short-circuit that re-entry and avoid an infinite loop.
+</Callout>
+
+Your `.md` twins live in `public/` (e.g. `public/posts/hello.md` for `/posts/hello`). The middleware fetches them via `fetchAsset` and serves them with the full AEO header set; everything else falls through to `upstream` (`NextResponse.next()`).
+
+## Static sites & other frameworks
+
+The adapter isn't Next-specific — Vercel runs a root `middleware.ts` for any project. For a static site (or any non-Next framework on Vercel), supply an `upstream` that continues to the origin instead of `NextResponse.next()`:
+
+```ts title="middleware.src.ts"
+import { createAEOMiddleware } from "@dualmark/vercel";
+
+export default createAEOMiddleware({
+  // Tell Vercel to continue to the static origin (the `NextResponse.next()` signal, without Next):
+  upstream: () => new Response(null, { headers: { "x-middleware-next": "1" } }),
+  fetchAsset: async (url, init) => fetch(url.toString(), init),
+  trailingSlash: "never",
+  enableLinkHeader: true,
+});
+
+export const config = { matcher: ["/((?!_next/|favicon.ico).*)"] };
+```
+
+<Callout type="warn">
+  **Bundle your middleware.** Unlike Next.js, Vercel does not bundle dependencies for a bare middleware file — deploying one that imports `@dualmark/vercel` fails with `Edge Function "middleware" is referencing unsupported modules`. Author your middleware in a source file (e.g. `middleware.src.ts`) and bundle it into a single self-contained `middleware.js` — the only file Vercel should pick up as the entry — before deploying:
+
+  ```bash
+  esbuild middleware.src.ts --bundle --format=esm --target=es2022 --outfile=middleware.js
+  ```
+
+  (Any bundler works — tsup, rollup, etc. Run `npm install @dualmark/vercel @dualmark/core` first so the bundler can resolve them.)
+</Callout>
+
+A static deployment hits a clean **125/125** — with no Next.js `base-server` in the way, the `Vary: Accept` header survives on the HTML page too.
+
+## Redirects and hooks
+
+```ts title="proxy.ts"
+export default createAEOMiddleware({
+  upstream: async () => NextResponse.next(),
+  fetchAsset: async (url, init) => fetch(url.toString(), init),
+  redirects: {
+    internal: { "/old-path": "/new-path" },
+    external: { "/login": "https://app.example.com" },
+  },
+  hooks: {
+    onAIRequest: (info) => console.log(`${info.botName} hit ${info.pathname} (${info.tokens} tokens)`),
+    onMiss: (info) => console.warn(`miss: ${info.pathname}`),
+  },
+});
+```
+
+## Verify
+
+The example at `examples/vercel-edge-full` scores **120/125** under `next dev`:
+
+```bash
+next dev --port 3001
+# new terminal:
+bunx @dualmark/cli verify http://localhost:3001/posts/hello
+```
+
+<Callout type="info">
+  The only missed check is `html.vary` (recommended, −5). Next.js's `base-server` overwrites the HTML response's `Vary` header with its own internal RSC value, so `Vary: Accept` doesn't survive on the HTML page. This is a known Next.js limitation, not an adapter bug — the markdown twin still carries `Vary: Accept` correctly. 120/125 is **Standard+** conformance, well above the 80% threshold.
+</Callout>
+
+## What it does
+
+1. **Trailing slash enforcement** — configurable: `never` (default), `always`, `preserve`
+2. **AI bot detection** — via UA, against the registry of [24 known crawlers](/docs/spec/ai-bot-detection)
+3. **Content negotiation** — via Accept header, RFC 7231 §5.3.2 compliant
+4. **Markdown serving** — pre-built `.md` via `fetchAsset` with full AEO headers
+5. **Internal redirects** — routes to target's `.md` with `X-Redirect-From` / `X-Redirect-To`
+6. **External redirects** — returns a markdown notice with the target link
+7. **406 fallback** — when neither HTML nor markdown is acceptable
+8. **Link header injection** — `<…>; rel="alternate"; type="text/markdown"` on HTML responses
+9. **Lifecycle hooks** — `onAIRequest` / `onMiss`, optionally scheduled via `context.waitUntil`
+10. **Pass-through** — falls through to the upstream handler for everything else

--- a/apps/docs/content/docs/packages/meta.json
+++ b/apps/docs/content/docs/packages/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Packages",
-  "pages": ["core", "converters", "astro", "nextjs", "sveltekit", "cloudflare", "deno", "cli"]
+  "pages": ["core", "converters", "astro", "nextjs", "sveltekit", "cloudflare", "vercel", "deno", "cli"]
 }

--- a/apps/docs/content/docs/packages/vercel.mdx
+++ b/apps/docs/content/docs/packages/vercel.mdx
@@ -1,0 +1,102 @@
+---
+title: "@dualmark/vercel"
+description: Vercel Edge Middleware adapter — wraps any upstream handler.
+---
+
+<Tabs items={["bun", "npm", "yarn"]}>
+<Tab value="bun">
+```bash
+bun add @dualmark/vercel @dualmark/core
+```
+</Tab>
+<Tab value="npm">
+```bash
+npm install @dualmark/vercel @dualmark/core
+```
+</Tab>
+<Tab value="yarn">
+```bash
+yarn add @dualmark/vercel @dualmark/core
+```
+</Tab>
+</Tabs>
+
+## `createAEOMiddleware(options)`
+
+Returns `(request: Request, context?: VercelEdgeContext) => Promise<Response>` — export it from `proxy.ts` / `middleware.ts`.
+
+```ts
+import { NextResponse } from "next/server";
+import { createAEOMiddleware } from "@dualmark/vercel";
+
+export default createAEOMiddleware({
+  upstream: async () => NextResponse.next(),
+  fetchAsset: async (url, init) => fetch(url.toString(), init),
+  trailingSlash: "never",
+  enableLinkHeader: true,
+
+  redirects: {
+    internal: { "/old": "/new" },
+    external: { "/login": "https://app.example.com" },
+  },
+
+  skip: {
+    prefixes: ["/admin", "/api/"],
+    extensions: [".js", ".css", ".png"],
+  },
+
+  headers: { cacheControl: "public, max-age=3600" },
+
+  hooks: {
+    onAIRequest: (info) => console.log(info.botName, info.pathname),
+    onMiss: (info) => console.warn("miss:", info.pathname),
+  },
+});
+```
+
+## Options
+
+| Option | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `upstream` | `(request) => Response \| Promise<Response>` | required | Your upstream handler, typically `() => NextResponse.next()` |
+| `fetchAsset` | `(url, init?) => Promise<Response>` | required | Fetches pre-built `.md` assets. **Must forward `init`** so the subrequest header propagates |
+| `trailingSlash` | `"never" \| "always" \| "preserve"` | `"never"` | Redirect policy |
+| `enableLinkHeader` | `boolean` | `true` | Inject `Link rel="alternate"` on HTML |
+| `redirects.internal` | `Record<string, string>` | `{}` | Path → path |
+| `redirects.external` | `Record<string, string>` | `{}` | Path → URL |
+| `skip.prefixes` | `string[]` | `["/admin", "/api/", "/_"]` | Skip negotiation entirely |
+| `skip.extensions` | `string[]` | common assets | Skip negotiation for these extensions |
+| `headers.cacheControl` | `string` | `"public, max-age=3600"` | For markdown responses |
+| `hooks.onAIRequest` | `(info) => void \| Promise<void>` | `undefined` | Called on every AI hit |
+| `hooks.onMiss` | `(info) => void \| Promise<void>` | `undefined` | Called when no markdown is found |
+
+Pass the edge `context` (`middleware(request, context)`) to run async hooks via `context.waitUntil`; without it they are fire-and-forget.
+
+## Types
+
+```ts
+interface AIRequestInfo {
+  url: URL;
+  botName: string | null;
+  botVendor: string | null;
+  acceptHeader: string;
+  pathname: string;
+  cacheStatus: "hit" | "miss";
+  tokens: number;
+}
+
+interface MissInfo {
+  url: URL;
+  botName: string | null;
+  pathname: string;
+  acceptHeader: string;
+}
+
+interface VercelEdgeContext {
+  waitUntil: (promise: Promise<unknown>) => void;
+}
+```
+
+## Peer dependencies
+
+`next` is an **optional** peer dependency (`>=14`). The adapter dynamically imports `next/server` for passthrough and degrades gracefully if it isn't present, so the package also works outside Next.js as long as you supply your own `upstream` handler.

--- a/bun.lock
+++ b/bun.lock
@@ -104,6 +104,23 @@
         "vite": "^7.2.7",
       },
     },
+    "examples/vercel-edge-full": {
+      "name": "dualmark-example-vercel-edge-full",
+      "version": "0.0.1",
+      "dependencies": {
+        "@dualmark/core": "workspace:*",
+        "@dualmark/vercel": "workspace:*",
+        "next": "^16.2.6",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/react": "^19.2.0",
+        "@types/react-dom": "^19.2.0",
+        "typescript": "^5.5.0",
+      },
+    },
     "packages/astro": {
       "name": "@dualmark/astro",
       "version": "0.8.0",
@@ -228,6 +245,26 @@
         "vite": ">=5.0.0",
       },
     },
+    "packages/vercel": {
+      "name": "@dualmark/vercel",
+      "version": "0.1.0",
+      "dependencies": {
+        "@dualmark/core": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "next": "^16.2.6",
+        "tsup": "^8.3.5",
+        "typescript": "^5.7.2",
+        "vitest": "^2.1.8",
+      },
+      "peerDependencies": {
+        "next": ">=14.0.0",
+      },
+      "optionalPeers": [
+        "next",
+      ],
+    },
   },
   "trustedDependencies": [
     "@tailwindcss/oxide",
@@ -336,6 +373,8 @@
     "@dualmark/nextjs": ["@dualmark/nextjs@workspace:packages/nextjs"],
 
     "@dualmark/sveltekit": ["@dualmark/sveltekit@workspace:packages/sveltekit"],
+
+    "@dualmark/vercel": ["@dualmark/vercel@workspace:packages/vercel"],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
@@ -665,7 +704,7 @@
 
     "@sveltejs/adapter-auto": ["@sveltejs/adapter-auto@6.1.1", "", { "peerDependencies": { "@sveltejs/kit": "^2.0.0" } }, "sha512-cBNt4jgH4KuaNO5gRSB2CZKkGtz+OCZ8lPjRQGjhvVUD4akotnj2weUia6imLl2v07K3IgsQRyM36909miSwoQ=="],
 
-    "@sveltejs/kit": ["@sveltejs/kit@2.61.1", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@sveltejs/acorn-typescript": "^1.0.9", "@types/cookie": "^0.6.0", "acorn": "^8.16.0", "cookie": "^0.6.0", "devalue": "^5.8.1", "esm-env": "^1.2.2", "kleur": "^4.1.5", "magic-string": "^0.30.5", "mrmime": "^2.0.0", "set-cookie-parser": "^3.0.0", "sirv": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0", "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": "^5.3.3 || ^6.0.0", "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0" }, "optionalPeers": ["@opentelemetry/api", "typescript"], "bin": { "svelte-kit": "svelte-kit.js" } }, "sha512-Ny8s1SR1TyQS2hD2Rvw0XKzU2Nw1eUF52dTb6T2bdcgz7wSC+Nyb5IwjWYlR4b2dvbbR5NJDiQwHg3rnNseghg=="],
+    "@sveltejs/kit": ["@sveltejs/kit@2.62.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@sveltejs/acorn-typescript": "^1.0.9", "@types/cookie": "^0.6.0", "acorn": "^8.16.0", "cookie": "^0.6.0", "devalue": "^5.8.1", "esm-env": "^1.2.2", "kleur": "^4.1.5", "magic-string": "^0.30.5", "mrmime": "^2.0.0", "set-cookie-parser": "^3.0.0", "sirv": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0", "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": "^5.3.3 || ^6.0.0", "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0" }, "optionalPeers": ["@opentelemetry/api", "typescript"], "bin": { "svelte-kit": "svelte-kit.js" } }, "sha512-4JlkXGRJ3kW15dL4LCHV3Mu5aSTTtmH8EBNE4QjJl+KLY77dClgAsZg8aebpwFcDXemNP1z9az8EatD2UNWAcQ=="],
 
     "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@6.2.4", "", { "dependencies": { "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0", "deepmerge": "^4.3.1", "magic-string": "^0.30.21", "obug": "^2.1.0", "vitefu": "^1.1.1" }, "peerDependencies": { "svelte": "^5.0.0", "vite": "^6.3.0 || ^7.0.0" } }, "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA=="],
 
@@ -969,6 +1008,8 @@
 
     "dualmark-example-sveltekit-blog": ["dualmark-example-sveltekit-blog@workspace:examples/sveltekit-blog"],
 
+    "dualmark-example-vercel-edge-full": ["dualmark-example-vercel-edge-full@workspace:examples/vercel-edge-full"],
+
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
@@ -993,7 +1034,7 @@
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
-    "esrap": ["esrap@2.2.9", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" }, "peerDependencies": { "@typescript-eslint/types": "^8.2.0" }, "optionalPeers": ["@typescript-eslint/types"] }, "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A=="],
+    "esrap": ["esrap@2.2.11", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" }, "peerDependencies": { "@typescript-eslint/types": "^8.2.0" }, "optionalPeers": ["@typescript-eslint/types"] }, "sha512-gPdx+I+BjYEinNMQaBXFjbaJVyoPMU4ZODg5mE+M4DqVG9VusAVHHjcBX+zqyITlI0DIARwDMMzZwAWj36dRoQ=="],
 
     "estree-util-attach-comments": ["estree-util-attach-comments@3.0.0", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw=="],
 
@@ -1667,7 +1708,7 @@
 
     "suspend-react": ["suspend-react@0.1.3", "", { "peerDependencies": { "react": ">=17.0" } }, "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ=="],
 
-    "svelte": ["svelte@5.56.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.9", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-kTXr26t1bchFp28ROrb957LtbujpBmBDibmqMGziVpUs7awBi96TGgX6SovrA8BNoEUDVRK2Fb9FkeYlGspoVg=="],
+    "svelte": ["svelte@5.56.1", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.9", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-eArsJmvl3xZVuTYD852PzIEdg2wgDdIZ1NEsIPbzAukHwi284B18No4nK2rCO9AwsWUDza4Cjvmoa4HaojTl5g=="],
 
     "svgo": ["svgo@4.0.1", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.5.0" }, "bin": "./bin/svgo.js" }, "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w=="],
 

--- a/examples/vercel-edge-full/README.md
+++ b/examples/vercel-edge-full/README.md
@@ -1,0 +1,66 @@
+# dualmark-example-vercel-edge-full
+
+Reference: a Next.js site deployed to Vercel with `@dualmark/vercel` Edge Middleware, so AI bots get markdown at the edge.
+
+## Architecture
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│ Vercel Edge Proxy (proxy.ts)                                  │
+│   createAEOMiddleware({                                       │
+│     upstream: () => NextResponse.next(),                      │
+│     fetchAsset: (url, init) => fetch(url, init),              │
+│     trailingSlash: "never",                                   │
+│     enableLinkHeader: true,                                   │
+│   })                                                          │
+│                                                               │
+│   ↓ AI bot UA + Accept: text/markdown                         │
+│   → fetches /posts/foo.md via fetchAsset (subrequest header)  │
+│   → subrequest returns NextResponse.next() → static file      │
+│   → adapter adds AEO headers, returns to client               │
+│                                                               │
+│   ↓ Human / unknown UA                                        │
+│   → upstream returns NextResponse.next() → origin renders HTML│
+│   → adapter appends `Link rel="alternate"` header in-place    │
+└───────────────────────────────────────────────────────────────┘
+```
+
+## Setup
+
+```bash
+bun install
+bun run build        # next build → static HTML pages
+```
+
+## Run locally
+
+```bash
+bun run dev          # http://localhost:3001
+```
+
+Test the negotiation:
+
+```bash
+# As a browser → HTML with Link header
+curl -sI http://localhost:3001/posts/hello
+
+# As ChatGPT → markdown
+curl -sI -H "User-Agent: GPTBot/1.0" http://localhost:3001/posts/hello
+
+# Direct .md path → markdown with AEO headers
+curl -sI http://localhost:3001/posts/hello.md
+```
+
+## Deploy
+
+Push to Vercel — the middleware runs automatically on the edge.
+
+## Verify with the CLI
+
+```bash
+bunx @dualmark/cli verify http://localhost:3001/posts/hello
+```
+
+## License
+
+Apache 2.0

--- a/examples/vercel-edge-full/app/layout.tsx
+++ b/examples/vercel-edge-full/app/layout.tsx
@@ -1,0 +1,12 @@
+export const metadata = {
+  title: "Dualmark Vercel Edge Example",
+  description: "Reference implementation of Dualmark on Vercel Edge Middleware.",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/examples/vercel-edge-full/app/page.tsx
+++ b/examples/vercel-edge-full/app/page.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+import { POSTS } from "@/lib/posts";
+
+export default function HomePage() {
+  return (
+    <main>
+      <h1>Dualmark Vercel Edge Example</h1>
+      <p>
+        Every page has a markdown twin. Append <code>.md</code> to any URL.
+      </p>
+      <h2>Posts</h2>
+      <ul>
+        {POSTS.map((p) => (
+          <li key={p.slug}>
+            <Link href={`/posts/${p.slug}`}>{p.title}</Link> — {p.description}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/examples/vercel-edge-full/app/posts/[slug]/page.tsx
+++ b/examples/vercel-edge-full/app/posts/[slug]/page.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getPost, POSTS } from "@/lib/posts";
+
+export function generateStaticParams() {
+  return POSTS.map((p) => ({ slug: p.slug }));
+}
+
+export default async function PostPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const post = getPost(slug);
+  if (!post) notFound();
+  return (
+    <main>
+      <article>
+        <h1>{post.title}</h1>
+        <p>
+          By <strong>{post.author}</strong> — {post.publishedDate}
+        </p>
+        {post.body.split("\n\n").map((para, i) => (
+          <p key={i}>{para}</p>
+        ))}
+      </article>
+      <p>
+        <Link href="/posts">← All posts</Link>
+      </p>
+    </main>
+  );
+}

--- a/examples/vercel-edge-full/lib/posts.ts
+++ b/examples/vercel-edge-full/lib/posts.ts
@@ -1,0 +1,46 @@
+export interface Post {
+  slug: string;
+  title: string;
+  description: string;
+  author: string;
+  publishedDate: string;
+  category: string;
+  body: string;
+}
+
+export const POSTS: Post[] = [
+  {
+    slug: "hello",
+    title: "Hello from Vercel Edge + Dualmark",
+    description: "First post demonstrating @dualmark/vercel edge middleware.",
+    author: "Sisyphus",
+    publishedDate: "2026-05-24",
+    category: "announcements",
+    body: `This is the **first post** demonstrating the \`@dualmark/vercel\` edge adapter.
+
+Every page on this site has a markdown twin. Append \`.md\` to any URL or send \`Accept: text/markdown\`.
+
+## How it works
+
+The Vercel Edge Middleware intercepts every request, checks the User-Agent and Accept headers, and serves markdown to AI bots — all at the edge, with zero cold-start overhead.`,
+  },
+  {
+    slug: "negotiation",
+    title: "Edge content negotiation",
+    description: "How the Vercel edge adapter handles Accept negotiation.",
+    author: "Sisyphus",
+    publishedDate: "2026-05-24",
+    category: "explainers",
+    body: `When a request arrives at the Vercel Edge Middleware:
+
+- Known AI bot UA → respond with markdown
+- \`Accept: text/markdown\` → respond with markdown
+- Otherwise → respond with HTML, plus a \`Link: <…>; rel="alternate"\` header
+
+This way the **same URL** serves the right content to the right consumer — no duplicate URLs, no cloaking.`,
+  },
+];
+
+export function getPost(slug: string): Post | undefined {
+  return POSTS.find((p) => p.slug === slug);
+}

--- a/examples/vercel-edge-full/next.config.mjs
+++ b/examples/vercel-edge-full/next.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  trailingSlash: false,
+};
+
+export default nextConfig;

--- a/examples/vercel-edge-full/package.json
+++ b/examples/vercel-edge-full/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "dualmark-example-vercel-edge-full",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --port 3001",
+    "build": "next build",
+    "start": "next start --port 3001",
+    "verify": "node ../../packages/cli/dist/cli.js verify http://localhost:3001/posts/hello"
+  },
+  "dependencies": {
+    "@dualmark/core": "workspace:*",
+    "@dualmark/vercel": "workspace:*",
+    "next": "^16.2.6",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.2.0",
+    "@types/react-dom": "^19.2.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/examples/vercel-edge-full/proxy.ts
+++ b/examples/vercel-edge-full/proxy.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { createAEOMiddleware } from "@dualmark/vercel";
+
+const middleware = createAEOMiddleware({
+  upstream: async () => NextResponse.next(),
+  fetchAsset: async (url, init) => fetch(url.toString(), init),
+  trailingSlash: "never",
+  enableLinkHeader: true,
+  analytics: {
+    onAIRequest: (info) => {
+      console.log(
+        `[dualmark] ai-hit bot=${info.botName ?? "?"} path=${info.pathname} cache=${info.cacheStatus} tokens=${info.tokens}`,
+      );
+    },
+    onMiss: (info) => {
+      console.warn(`[dualmark] miss bot=${info.botName ?? "?"} path=${info.pathname}`);
+    },
+  },
+});
+
+export default middleware;
+
+export const config = {
+  matcher: [
+    {
+      source: "/((?!_next/|favicon.ico).*)",
+      missing: [{ type: "header", key: "next-router-prefetch" }],
+    },
+  ],
+};

--- a/examples/vercel-edge-full/proxy.ts
+++ b/examples/vercel-edge-full/proxy.ts
@@ -6,7 +6,7 @@ const middleware = createAEOMiddleware({
   fetchAsset: async (url, init) => fetch(url.toString(), init),
   trailingSlash: "never",
   enableLinkHeader: true,
-  analytics: {
+  hooks: {
     onAIRequest: (info) => {
       console.log(
         `[dualmark] ai-hit bot=${info.botName ?? "?"} path=${info.pathname} cache=${info.cacheStatus} tokens=${info.tokens}`,

--- a/examples/vercel-edge-full/public/index.md
+++ b/examples/vercel-edge-full/public/index.md
@@ -1,0 +1,10 @@
+# Dualmark Vercel Edge Example
+
+> Reference implementation of Dualmark on Vercel Edge Middleware.
+
+A minimal site demonstrating the `@dualmark/vercel` edge adapter — the middleware handles negotiation and serves markdown twins at the edge.
+
+## Posts
+
+- [Hello from Vercel Edge + Dualmark](/posts/hello)
+- [Edge content negotiation](/posts/negotiation)

--- a/examples/vercel-edge-full/public/posts/hello.md
+++ b/examples/vercel-edge-full/public/posts/hello.md
@@ -1,0 +1,15 @@
+# Hello from Vercel Edge + Dualmark
+
+> First post demonstrating @dualmark/vercel edge middleware.
+
+- **Author**: Sisyphus
+- **Date**: 2026-05-24
+- **Category**: announcements
+
+This is the **first post** demonstrating the `@dualmark/vercel` edge adapter.
+
+Every page on this site has a markdown twin. Append `.md` to any URL or send `Accept: text/markdown`.
+
+## How it works
+
+The Vercel Edge Middleware intercepts every request, checks the User-Agent and Accept headers, and serves markdown to AI bots — all at the edge, with zero cold-start overhead.

--- a/examples/vercel-edge-full/public/posts/negotiation.md
+++ b/examples/vercel-edge-full/public/posts/negotiation.md
@@ -1,0 +1,15 @@
+# Edge content negotiation
+
+> How the Vercel edge adapter handles Accept negotiation.
+
+- **Author**: Sisyphus
+- **Date**: 2026-05-24
+- **Category**: explainers
+
+When a request arrives at the Vercel Edge Middleware:
+
+- Known AI bot UA → respond with markdown
+- `Accept: text/markdown` → respond with markdown
+- Otherwise → respond with HTML, plus a `Link: <…>; rel="alternate"` header
+
+This way the **same URL** serves the right content to the right consumer — no duplicate URLs, no cloaking.

--- a/examples/vercel-edge-full/tsconfig.json
+++ b/examples/vercel-edge-full/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/packages/vercel/LICENSE
+++ b/packages/vercel/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing the Work or
+      Derivative Works thereof, You may choose to offer, and charge a
+      fee for, acceptance of support, warranty, indemnity, or other
+      liability obligations and/or rights consistent with this License.
+      However, in accepting such obligations, You may act only on Your
+      own behalf and on Your sole responsibility, not on behalf of any
+      other Contributor, and only if You agree to indemnify, defend, and
+      hold each Contributor harmless for any liability incurred by, or
+      claims asserted against, such Contributor by reason of your accepting
+      any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Dodo Payments
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/vercel/README.md
+++ b/packages/vercel/README.md
@@ -20,7 +20,7 @@ const middleware = createAEOMiddleware({
   fetchAsset: async (url, init) => fetch(url.toString(), init),
   trailingSlash: "never",
   enableLinkHeader: true,
-  analytics: {
+  hooks: {
     onAIRequest: (info) => console.log(`${info.botName} hit ${info.pathname}`),
     onMiss: (info) => console.warn(`miss: ${info.pathname}`),
   },
@@ -53,7 +53,7 @@ Vercel Edge Middleware re-triggers for same-origin `fetch()` calls. To prevent i
 | `fetchAsset`       | `(url, init?) => Response`          | —         | Fetch a `.md` file by URL (forward `init` to `fetch`)       |
 | `trailingSlash`    | `"never" \| "always" \| "preserve"` | `"never"` | Trailing slash mode                                         |
 | `enableLinkHeader` | `boolean`                           | `true`    | Inject `Link rel=alternate` on HTML responses               |
-| `analytics`        | `{ onAIRequest?, onMiss? }`         | —         | Vercel Analytics / OTel hooks                               |
+| `hooks`            | `{ onAIRequest?, onMiss? }`         | —         | Lifecycle callbacks for AI request events                   |
 | `redirects`        | `{ internal?, external? }`          | —         | Redirect rules for AI bots                                  |
 | `skip`             | `{ prefixes?, extensions? }`        | —         | Paths to skip entirely                                      |
 | `headers`          | `{ cacheControl? }`                 | —         | Custom response headers                                     |

--- a/packages/vercel/README.md
+++ b/packages/vercel/README.md
@@ -1,0 +1,76 @@
+# @dualmark/vercel
+
+Vercel Edge Middleware adapter for the Dualmark AEO framework. Wraps any upstream handler and transparently serves markdown to AI bots at the edge — no changes to your existing site.
+
+## Install
+
+```bash
+bun add @dualmark/vercel @dualmark/core
+```
+
+## Usage
+
+```ts
+// proxy.ts
+import { NextResponse } from "next/server";
+import { createAEOMiddleware } from "@dualmark/vercel";
+
+const middleware = createAEOMiddleware({
+  upstream: async () => NextResponse.next(),
+  fetchAsset: async (url, init) => fetch(url.toString(), init),
+  trailingSlash: "never",
+  enableLinkHeader: true,
+  analytics: {
+    onAIRequest: (info) => console.log(`${info.botName} hit ${info.pathname}`),
+    onMiss: (info) => console.warn(`miss: ${info.pathname}`),
+  },
+});
+
+export default middleware;
+
+export const config = {
+  matcher: [
+    {
+      source: "/((?!_next/|favicon.ico).*)",
+      missing: [{ type: "header", key: "next-router-prefetch" }],
+    },
+  ],
+};
+```
+
+## How it works on Vercel
+
+Vercel Edge Middleware re-triggers for same-origin `fetch()` calls. To prevent infinite loops, the adapter adds an `x-dualmark-subrequest` header to internal `fetchAsset` calls and short-circuits when it detects a subrequest — returning `NextResponse.next()` so Vercel serves the static file directly.
+
+- **`upstream`** should return `NextResponse.next()` for browser requests. The adapter injects Link headers directly on the response object.
+- **`fetchAsset`** should forward the optional `RequestInit` to `fetch()` so the subrequest header is included.
+
+## Options
+
+| Option             | Type                                | Default   | Description                                                 |
+| ------------------ | ----------------------------------- | --------- | ----------------------------------------------------------- |
+| `upstream`         | `(req) => Response`                 | —         | Handler for non-bot requests (return `NextResponse.next()`) |
+| `fetchAsset`       | `(url, init?) => Response`          | —         | Fetch a `.md` file by URL (forward `init` to `fetch`)       |
+| `trailingSlash`    | `"never" \| "always" \| "preserve"` | `"never"` | Trailing slash mode                                         |
+| `enableLinkHeader` | `boolean`                           | `true`    | Inject `Link rel=alternate` on HTML responses               |
+| `analytics`        | `{ onAIRequest?, onMiss? }`         | —         | Vercel Analytics / OTel hooks                               |
+| `redirects`        | `{ internal?, external? }`          | —         | Redirect rules for AI bots                                  |
+| `skip`             | `{ prefixes?, extensions? }`        | —         | Paths to skip entirely                                      |
+| `headers`          | `{ cacheControl? }`                 | —         | Custom response headers                                     |
+
+## What it does
+
+1. Subrequest detection to prevent `fetch()` infinite loops on Vercel
+2. Trailing-slash enforcement (configurable: `never`, `always`, `preserve`)
+3. AI bot detection via UA
+4. Content negotiation via Accept header
+5. Serves pre-built `.md` via `fetchAsset` with full AEO headers
+6. Internal redirects: routes to target's `.md`
+7. External redirects: returns markdown notice
+8. 406 when neither HTML nor markdown is acceptable
+9. Link header injection on upstream `NextResponse.next()` for HTML responses
+10. Analytics hooks (onAIRequest / onMiss)
+
+## License
+
+Apache 2.0

--- a/packages/vercel/package.json
+++ b/packages/vercel/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@dualmark/vercel",
+  "version": "0.1.0",
+  "description": "Vercel Edge Middleware adapter for the Dualmark AEO framework. Wraps any upstream handler and transparently serves markdown to AI bots at the edge.",
+  "license": "Apache-2.0",
+  "author": "Dodo Payments <opensource@dodopayments.com> (https://dodopayments.com)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dodopayments/dualmark.git",
+    "directory": "packages/vercel"
+  },
+  "bugs": {
+    "url": "https://github.com/dodopayments/dualmark/issues"
+  },
+  "homepage": "https://github.com/dodopayments/dualmark/tree/main/packages/vercel#readme",
+  "funding": "https://github.com/sponsors/dodopayments",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist .turbo"
+  },
+  "peerDependencies": {
+    "next": ">=14.0.0"
+  },
+  "peerDependenciesMeta": {
+    "next": {
+      "optional": true
+    }
+  },
+  "dependencies": {
+    "@dualmark/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "next": "^16.2.6",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "keywords": [
+    "aeo",
+    "answer-engine-optimization",
+    "vercel",
+    "vercel-edge",
+    "edge-middleware",
+    "edge",
+    "ai-agents",
+    "ai-search",
+    "markdown",
+    "dualmark"
+  ],
+  "engines": {
+    "node": ">=22.12.0"
+  }
+}

--- a/packages/vercel/src/index.ts
+++ b/packages/vercel/src/index.ts
@@ -1,0 +1,10 @@
+export { createAEOMiddleware } from "./middleware.js";
+export type {
+  CreateAEOMiddlewareOptions,
+  AssetFetcher,
+  UpstreamHandler,
+  VercelEdgeContext,
+  AIRequestInfo,
+  MissInfo,
+  TrailingSlashMode,
+} from "./types.js";

--- a/packages/vercel/src/middleware.ts
+++ b/packages/vercel/src/middleware.ts
@@ -109,8 +109,8 @@ export function createAEOMiddleware(
   const cacheControl = options.headers?.cacheControl ?? DEFAULT_CACHE_CONTROL;
   const enableLinkHeader = options.enableLinkHeader !== false;
 
-  const onAIRequest = options.analytics?.onAIRequest;
-  const onMiss = options.analytics?.onMiss;
+  const onAIRequest = options.hooks?.onAIRequest;
+  const onMiss = options.hooks?.onMiss;
 
   async function middleware(request: Request, context?: VercelEdgeContext): Promise<Response> {
     // Subrequest passthrough — prevents infinite loops when fetchAsset
@@ -118,7 +118,7 @@ export function createAEOMiddleware(
     if (request.headers.get(SUBREQUEST_HEADER)) {
       const NextResponse = await getNextResponse();
       if (NextResponse) return NextResponse.next();
-      return new Response(null, { status: 204 });
+      return new Response(null, { status: 200 });
     }
 
     const url = new URL(request.url);

--- a/packages/vercel/src/middleware.ts
+++ b/packages/vercel/src/middleware.ts
@@ -78,23 +78,23 @@ function buildMarkdownHeaders(
   return headers;
 }
 
-function appendLinkHeader(response: Response, mdPath: string): void {
+function appendLinkHeader(headers: Headers, mdPath: string): void {
   const link = `<${mdPath}>; rel="alternate"; type="text/markdown"`;
-  const existing = response.headers.get("Link");
-  response.headers.set("Link", existing ? `${existing}, ${link}` : link);
+  const existing = headers.get("Link");
+  headers.set("Link", existing ? `${existing}, ${link}` : link);
 }
 
-function appendVaryAccept(response: Response): void {
-  const vary = response.headers.get("Vary");
+function appendVaryAccept(headers: Headers): void {
+  const vary = headers.get("Vary");
   if (!vary) {
-    response.headers.set("Vary", "Accept");
+    headers.set("Vary", "Accept");
   } else if (
     !vary
       .split(",")
       .map((s) => s.trim().toLowerCase())
       .includes("accept")
   ) {
-    response.headers.set("Vary", `${vary}, Accept`);
+    headers.set("Vary", `${vary}, Accept`);
   }
 }
 
@@ -308,25 +308,13 @@ export function createAEOMiddleware(
         try {
           // Fast path: mutate headers in-place (works for NextResponse.next() and
           // freshly constructed Response objects).
-          appendLinkHeader(upstreamResponse, mdPath);
-          appendVaryAccept(upstreamResponse);
+          appendLinkHeader(upstreamResponse.headers, mdPath);
+          appendVaryAccept(upstreamResponse.headers);
         } catch {
           // Immutable headers (e.g. from fetch()) — clone into new Response.
           const newHeaders = new Headers(upstreamResponse.headers);
-          const link = `<${mdPath}>; rel="alternate"; type="text/markdown"`;
-          const existing = newHeaders.get("Link");
-          newHeaders.set("Link", existing ? `${existing}, ${link}` : link);
-          const vary = newHeaders.get("Vary");
-          if (!vary) {
-            newHeaders.set("Vary", "Accept");
-          } else if (
-            !vary
-              .split(",")
-              .map((s) => s.trim().toLowerCase())
-              .includes("accept")
-          ) {
-            newHeaders.set("Vary", `${vary}, Accept`);
-          }
+          appendLinkHeader(newHeaders, mdPath);
+          appendVaryAccept(newHeaders);
           return new Response(upstreamResponse.body, {
             status: upstreamResponse.status,
             statusText: upstreamResponse.statusText,

--- a/packages/vercel/src/middleware.ts
+++ b/packages/vercel/src/middleware.ts
@@ -1,0 +1,343 @@
+import { detectAIBot, estimateTokens, negotiateFormat, toMarkdownPath } from "@dualmark/core";
+import type { AIRequestInfo, MissInfo } from "./types.js";
+import type { CreateAEOMiddlewareOptions, VercelEdgeContext } from "./types.js";
+
+const DEFAULT_SKIP_PREFIXES = ["/admin", "/api/", "/_"];
+const DEFAULT_ASSET_EXTENSIONS = [
+  ".js",
+  ".css",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".webp",
+  ".svg",
+  ".gif",
+  ".ico",
+  ".woff",
+  ".woff2",
+  ".xml",
+  ".json",
+  ".txt",
+  ".pdf",
+];
+
+const DEFAULT_CACHE_CONTROL = "public, max-age=3600";
+const SUBREQUEST_HEADER = "x-dualmark-subrequest";
+
+interface NextLikeResponseStatic {
+  next: () => Response;
+}
+
+// Cached at module init — one dynamic import at cold start, not per-request.
+// Intentionally cached for edge runtime lifetime.
+let _NextResponse: NextLikeResponseStatic | null = null;
+
+async function getNextResponse(): Promise<NextLikeResponseStatic | null> {
+  if (_NextResponse !== null) return _NextResponse;
+  try {
+    const mod = (await import("next/server")) as { NextResponse: NextLikeResponseStatic };
+    _NextResponse = mod.NextResponse;
+    return _NextResponse;
+  } catch {
+    _NextResponse = null;
+    return null;
+  }
+}
+
+function shouldSkip(
+  pathname: string,
+  prefixes: ReadonlyArray<string>,
+  extensions: ReadonlyArray<string>,
+): boolean {
+  if (extensions.some((ext) => pathname.endsWith(ext))) return true;
+  return prefixes.some((p) => pathname.startsWith(p));
+}
+
+function normalizePath(pathname: string): string {
+  return pathname.replace(/\/$/, "") || "/";
+}
+
+function buildMarkdownHeaders(
+  body: string,
+  cacheControl: string,
+  redirectFrom?: string,
+  redirectTo?: string,
+): Headers {
+  const tokens = estimateTokens(body);
+  const headers = new Headers({
+    "Content-Type": "text/markdown; charset=utf-8",
+    "X-Content-Type-Options": "nosniff",
+    "X-Robots-Tag": "noindex",
+    "X-Markdown-Tokens": String(tokens),
+    "X-AEO-Version": "1.0",
+    "Cache-Control": cacheControl,
+    Vary: "Accept",
+  });
+  if (redirectFrom) headers.set("X-Redirect-From", redirectFrom);
+  if (redirectTo) headers.set("X-Redirect-To", redirectTo);
+  return headers;
+}
+
+function appendLinkHeader(response: Response, mdPath: string): void {
+  const link = `<${mdPath}>; rel="alternate"; type="text/markdown"`;
+  const existing = response.headers.get("Link");
+  response.headers.set("Link", existing ? `${existing}, ${link}` : link);
+}
+
+function appendVaryAccept(response: Response): void {
+  const vary = response.headers.get("Vary");
+  if (!vary) {
+    response.headers.set("Vary", "Accept");
+  } else if (
+    !vary
+      .split(",")
+      .map((s) => s.trim().toLowerCase())
+      .includes("accept")
+  ) {
+    response.headers.set("Vary", `${vary}, Accept`);
+  }
+}
+
+export function createAEOMiddleware(
+  options: CreateAEOMiddlewareOptions,
+): (request: Request, context?: VercelEdgeContext) => Promise<Response> {
+  const skipPrefixes = options.skip?.prefixes ?? DEFAULT_SKIP_PREFIXES;
+  const skipExtensions = options.skip?.extensions ?? DEFAULT_ASSET_EXTENSIONS;
+  const internalRedirects = options.redirects?.internal ?? {};
+  const externalRedirects = options.redirects?.external ?? {};
+  const trailingSlash = options.trailingSlash ?? "never";
+  const cacheControl = options.headers?.cacheControl ?? DEFAULT_CACHE_CONTROL;
+  const enableLinkHeader = options.enableLinkHeader !== false;
+
+  const onAIRequest = options.analytics?.onAIRequest;
+  const onMiss = options.analytics?.onMiss;
+
+  async function middleware(request: Request, context?: VercelEdgeContext): Promise<Response> {
+    // Subrequest passthrough — prevents infinite loops when fetchAsset
+    // calls fetch() to the same origin on Vercel.
+    if (request.headers.get(SUBREQUEST_HEADER)) {
+      const NextResponse = await getNextResponse();
+      if (NextResponse) return NextResponse.next();
+      return new Response(null, { status: 204 });
+    }
+
+    const url = new URL(request.url);
+    const pathname = url.pathname;
+
+    if (
+      trailingSlash === "never" &&
+      pathname !== "/" &&
+      pathname.endsWith("/") &&
+      !shouldSkip(pathname, skipPrefixes, skipExtensions)
+    ) {
+      const clean = pathname.replace(/\/+$/, "");
+      const target = new URL(clean + url.search, url.origin);
+      return new Response(null, {
+        status: 301,
+        headers: { Location: target.href },
+      });
+    }
+    if (
+      trailingSlash === "always" &&
+      pathname !== "/" &&
+      !pathname.endsWith("/") &&
+      !pathname.endsWith(".md") &&
+      !shouldSkip(pathname, skipPrefixes, skipExtensions)
+    ) {
+      const target = new URL(pathname + "/" + url.search, url.origin);
+      return new Response(null, { status: 301, headers: { Location: target.href } });
+    }
+
+    const subrequestInit: RequestInit = {
+      headers: { [SUBREQUEST_HEADER]: "1" },
+    };
+
+    if (pathname.endsWith(".md") && !shouldSkip(pathname, skipPrefixes, skipExtensions)) {
+      let assetResponse: Response | null = null;
+      try {
+        assetResponse = await options.fetchAsset(new URL(pathname, url.origin), subrequestInit);
+      } catch {
+        assetResponse = null;
+      }
+      if (assetResponse && assetResponse.ok) {
+        const body = await assetResponse.text();
+        return new Response(body, {
+          status: 200,
+          headers: buildMarkdownHeaders(body, cacheControl),
+        });
+      }
+      return assetResponse ?? new Response("Not Found", { status: 404 });
+    }
+
+    if (!pathname.endsWith(".md") && !shouldSkip(pathname, skipPrefixes, skipExtensions)) {
+      const ua = request.headers.get("user-agent") ?? "";
+      const accept = request.headers.get("accept") ?? "";
+      const bot = detectAIBot(ua);
+      const fmt = negotiateFormat(accept);
+
+      if (fmt === null && accept) {
+        return new Response("Not Acceptable\n\nSupported types: text/html, text/markdown\n", {
+          status: 406,
+          headers: {
+            "Content-Type": "text/plain; charset=utf-8",
+            Vary: "Accept",
+          },
+        });
+      }
+
+      const serveMarkdown = bot.isBot || fmt === "markdown";
+
+      if (serveMarkdown) {
+        const mdPath = toMarkdownPath(pathname);
+        const assetUrl = new URL(mdPath, url.origin);
+        let assetResponse: Response | null = null;
+        try {
+          assetResponse = await options.fetchAsset(assetUrl, subrequestInit);
+        } catch {
+          assetResponse = null;
+        }
+
+        if (assetResponse && assetResponse.ok) {
+          const body = await assetResponse.text();
+          const tokens = estimateTokens(body);
+          const info: AIRequestInfo = {
+            url,
+            botName: bot.name,
+            botVendor: bot.vendor,
+            acceptHeader: accept,
+            pathname,
+            cacheStatus: "hit",
+            tokens,
+          };
+          if (onAIRequest && context) context.waitUntil(Promise.resolve(onAIRequest(info)));
+          else if (onAIRequest) onAIRequest(info);
+          return new Response(body, {
+            status: 200,
+            headers: buildMarkdownHeaders(body, cacheControl),
+          });
+        }
+
+        const cleanPath = normalizePath(pathname);
+        const internalTarget = internalRedirects[cleanPath];
+        if (internalTarget) {
+          const targetMd = toMarkdownPath(internalTarget);
+          try {
+            const targetResp = await options.fetchAsset(
+              new URL(targetMd, url.origin),
+              subrequestInit,
+            );
+            if (targetResp.ok) {
+              const body = await targetResp.text();
+              const tokens = estimateTokens(body);
+              const info: AIRequestInfo = {
+                url,
+                botName: bot.name,
+                botVendor: bot.vendor,
+                acceptHeader: accept,
+                pathname,
+                cacheStatus: "hit",
+                tokens,
+              };
+              if (onAIRequest && context) context.waitUntil(Promise.resolve(onAIRequest(info)));
+              else if (onAIRequest) onAIRequest(info);
+              return new Response(body, {
+                status: 200,
+                headers: buildMarkdownHeaders(body, cacheControl, cleanPath, internalTarget),
+              });
+            }
+          } catch {
+            // fall through to external check
+          }
+        }
+
+        const externalTarget = externalRedirects[cleanPath];
+        if (externalTarget) {
+          const body = `# Redirect\n\nThis page has moved to an external location.\n\n- **Redirect**: [${externalTarget}](${externalTarget})\n`;
+          const tokens = estimateTokens(body);
+          const info: AIRequestInfo = {
+            url,
+            botName: bot.name,
+            botVendor: bot.vendor,
+            acceptHeader: accept,
+            pathname,
+            cacheStatus: "hit",
+            tokens,
+          };
+          if (onAIRequest && context) context.waitUntil(Promise.resolve(onAIRequest(info)));
+          else if (onAIRequest) onAIRequest(info);
+          return new Response(body, {
+            status: 200,
+            headers: buildMarkdownHeaders(body, cacheControl, cleanPath, externalTarget),
+          });
+        }
+
+        const missInfo: MissInfo = {
+          url,
+          botName: bot.name,
+          pathname,
+          acceptHeader: accept,
+        };
+        const missAnalytics: AIRequestInfo = {
+          url,
+          botName: bot.name,
+          botVendor: bot.vendor,
+          acceptHeader: accept,
+          pathname,
+          cacheStatus: "miss",
+          tokens: 0,
+        };
+        if (onAIRequest && context) context.waitUntil(Promise.resolve(onAIRequest(missAnalytics)));
+        else if (onAIRequest) onAIRequest(missAnalytics);
+        if (onMiss && context) context.waitUntil(Promise.resolve(onMiss(missInfo)));
+        else if (onMiss) onMiss(missInfo);
+      }
+    }
+
+    const upstreamResponse = await options.upstream(request);
+
+    if (
+      enableLinkHeader &&
+      !shouldSkip(pathname, skipPrefixes, skipExtensions) &&
+      !pathname.endsWith(".md")
+    ) {
+      const ct = upstreamResponse.headers.get("content-type");
+      // Passthrough responses (e.g. NextResponse.next()) have no content-type yet —
+      // always inject. For concrete responses, only inject on text/html.
+      if (!ct || ct.includes("text/html")) {
+        const mdPath = toMarkdownPath(pathname);
+        try {
+          // Fast path: mutate headers in-place (works for NextResponse.next() and
+          // freshly constructed Response objects).
+          appendLinkHeader(upstreamResponse, mdPath);
+          appendVaryAccept(upstreamResponse);
+        } catch {
+          // Immutable headers (e.g. from fetch()) — clone into new Response.
+          const newHeaders = new Headers(upstreamResponse.headers);
+          const link = `<${mdPath}>; rel="alternate"; type="text/markdown"`;
+          const existing = newHeaders.get("Link");
+          newHeaders.set("Link", existing ? `${existing}, ${link}` : link);
+          const vary = newHeaders.get("Vary");
+          if (!vary) {
+            newHeaders.set("Vary", "Accept");
+          } else if (
+            !vary
+              .split(",")
+              .map((s) => s.trim().toLowerCase())
+              .includes("accept")
+          ) {
+            newHeaders.set("Vary", `${vary}, Accept`);
+          }
+          return new Response(upstreamResponse.body, {
+            status: upstreamResponse.status,
+            statusText: upstreamResponse.statusText,
+            headers: newHeaders,
+          });
+        }
+      }
+    }
+
+    return upstreamResponse;
+  }
+
+  return middleware;
+}

--- a/packages/vercel/src/middleware.ts
+++ b/packages/vercel/src/middleware.ts
@@ -277,17 +277,6 @@ export function createAEOMiddleware(
           pathname,
           acceptHeader: accept,
         };
-        const missAnalytics: AIRequestInfo = {
-          url,
-          botName: bot.name,
-          botVendor: bot.vendor,
-          acceptHeader: accept,
-          pathname,
-          cacheStatus: "miss",
-          tokens: 0,
-        };
-        if (onAIRequest && context) context.waitUntil(Promise.resolve(onAIRequest(missAnalytics)));
-        else if (onAIRequest) onAIRequest(missAnalytics);
         if (onMiss && context) context.waitUntil(Promise.resolve(onMiss(missInfo)));
         else if (onMiss) onMiss(missInfo);
       }

--- a/packages/vercel/src/types.ts
+++ b/packages/vercel/src/types.ts
@@ -1,0 +1,35 @@
+import type { AIRequestInfo, MissInfo, TrailingSlashMode } from "@dualmark/core";
+
+export type { AIRequestInfo, MissInfo, TrailingSlashMode };
+
+export interface VercelEdgeContext {
+  waitUntil: (promise: Promise<unknown>) => void;
+}
+
+export type AssetFetcher = (url: URL, init?: RequestInit) => Promise<Response>;
+
+export type UpstreamHandler = (request: Request) => Promise<Response> | Response;
+
+export interface CreateAEOMiddlewareOptions {
+  upstream: UpstreamHandler;
+  fetchAsset: AssetFetcher;
+  redirects?: {
+    internal?: Record<string, string>;
+    external?: Record<string, string>;
+  };
+  skip?: {
+    prefixes?: ReadonlyArray<string>;
+    extensions?: ReadonlyArray<string>;
+  };
+  trailingSlash?: TrailingSlashMode;
+  headers?: {
+    cacheControl?: string;
+  };
+  // Named `analytics` per issue #8 spec — replaces Cloudflare's binding-based
+  // `analytics` + generic `hooks` with a unified hook for Vercel Analytics/OTel.
+  analytics?: {
+    onAIRequest?: (info: AIRequestInfo) => void | Promise<void>;
+    onMiss?: (info: MissInfo) => void | Promise<void>;
+  };
+  enableLinkHeader?: boolean;
+}

--- a/packages/vercel/src/types.ts
+++ b/packages/vercel/src/types.ts
@@ -25,9 +25,7 @@ export interface CreateAEOMiddlewareOptions {
   headers?: {
     cacheControl?: string;
   };
-  // Named `analytics` per issue #8 spec — replaces Cloudflare's binding-based
-  // `analytics` + generic `hooks` with a unified hook for Vercel Analytics/OTel.
-  analytics?: {
+  hooks?: {
     onAIRequest?: (info: AIRequestInfo) => void | Promise<void>;
     onMiss?: (info: MissInfo) => void | Promise<void>;
   };

--- a/packages/vercel/test/middleware.test.ts
+++ b/packages/vercel/test/middleware.test.ts
@@ -1,0 +1,477 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createAEOMiddleware } from "../src/index.js";
+import type { AssetFetcher, UpstreamHandler, VercelEdgeContext } from "../src/types.js";
+
+function makeAssets(files: Record<string, string>): AssetFetcher {
+  return async (req, _init?) => {
+    const url = req instanceof URL ? req : new URL(String(req));
+    const body = files[url.pathname];
+    if (body === undefined) return new Response("Not found", { status: 404 });
+    return new Response(body, { status: 200 });
+  };
+}
+
+function makeUpstream(handler: (req: Request) => Response | Promise<Response>): UpstreamHandler {
+  return async (req) => handler(req);
+}
+
+function makeCtx(): VercelEdgeContext {
+  const promises: Promise<unknown>[] = [];
+  return {
+    waitUntil: (p) => {
+      promises.push(p);
+    },
+  };
+}
+
+describe("createAEOMiddleware — markdown serving", () => {
+  let fetchAsset: AssetFetcher;
+  beforeEach(() => {
+    fetchAsset = makeAssets({
+      "/blog/post-1.md": "# Post 1\n\nBody.",
+      "/index.md": "# Home\n\nWelcome.",
+    });
+  });
+
+  it("serves markdown to AI bot UA on existing path", async () => {
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(
+        () => new Response("html", { headers: { "Content-Type": "text/html" } }),
+      ),
+      fetchAsset,
+    });
+    const req = new Request("https://acme.test/blog/post-1", {
+      headers: { "user-agent": "GPTBot/1.0" },
+    });
+    const res = await middleware(req, makeCtx());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/markdown; charset=utf-8");
+    expect(res.headers.get("x-markdown-tokens")).toBe("4");
+    expect(res.headers.get("x-aeo-version")).toBe("1.0");
+    expect(res.headers.get("vary")).toBe("Accept");
+    expect(res.headers.get("x-robots-tag")).toBe("noindex");
+    expect(await res.text()).toBe("# Post 1\n\nBody.");
+  });
+
+  it("serves markdown when Accept: text/markdown (no bot UA)", async () => {
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(
+        () => new Response("html", { headers: { "Content-Type": "text/html" } }),
+      ),
+      fetchAsset,
+    });
+    const req = new Request("https://acme.test/blog/post-1", {
+      headers: { accept: "text/markdown" },
+    });
+    const res = await middleware(req, makeCtx());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/markdown; charset=utf-8");
+  });
+
+  it("returns 406 when Accept rules out html and markdown", async () => {
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(
+        () => new Response("html", { headers: { "Content-Type": "text/html" } }),
+      ),
+      fetchAsset,
+    });
+    const req = new Request("https://acme.test/blog/post-1", {
+      headers: { accept: "image/png" },
+    });
+    const res = await middleware(req, makeCtx());
+    expect(res.status).toBe(406);
+    expect(res.headers.get("vary")).toBe("Accept");
+  });
+
+  it("falls through to upstream for browser UA", async () => {
+    const upstreamMock = vi.fn(
+      (_req: Request) =>
+        new Response("<html>x</html>", { headers: { "Content-Type": "text/html" } }),
+    );
+    const middleware = createAEOMiddleware({
+      upstream: async (req) => upstreamMock(req),
+      fetchAsset,
+    });
+    const req = new Request("https://acme.test/blog/post-1", {
+      headers: {
+        "user-agent": "Mozilla/5.0 Chrome/130",
+        accept: "text/html,*/*;q=0.8",
+      },
+    });
+    const res = await middleware(req, makeCtx());
+    expect(upstreamMock).toHaveBeenCalledOnce();
+    expect(res.status).toBe(200);
+    const link = res.headers.get("link") ?? "";
+    expect(link).toContain('</blog/post-1.md>; rel="alternate"; type="text/markdown"');
+    expect(res.headers.get("vary")).toContain("Accept");
+  });
+
+  it("handles missing .md (cache miss) for bot — falls to upstream", async () => {
+    const upstreamMock = vi.fn(
+      (_req: Request) =>
+        new Response("<html>404</html>", {
+          status: 404,
+          headers: { "Content-Type": "text/html" },
+        }),
+    );
+    const middleware = createAEOMiddleware({
+      upstream: async (req) => upstreamMock(req),
+      fetchAsset,
+    });
+    const req = new Request("https://acme.test/blog/missing", {
+      headers: { "user-agent": "GPTBot/1.0" },
+    });
+    const res = await middleware(req, makeCtx());
+    expect(upstreamMock).toHaveBeenCalledOnce();
+    expect(res.status).toBe(404);
+  });
+
+  it("serves index.md for root path", async () => {
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(() => new Response("html")),
+      fetchAsset,
+    });
+    const req = new Request("https://acme.test/", {
+      headers: { "user-agent": "GPTBot/1.0" },
+    });
+    const res = await middleware(req, makeCtx());
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("# Home\n\nWelcome.");
+  });
+
+  it("decorates direct .md requests with full AEO headers from fetchAsset", async () => {
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(() => new Response("should-not-be-called", { status: 500 })),
+      fetchAsset,
+    });
+    const req = new Request("https://acme.test/blog/post-1.md");
+    const res = await middleware(req, makeCtx());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/markdown; charset=utf-8");
+    expect(res.headers.get("X-Markdown-Tokens")).toMatch(/^\d+$/);
+    expect(res.headers.get("X-Robots-Tag")).toBe("noindex");
+    expect(res.headers.get("Vary")).toBe("Accept");
+    expect(res.headers.get("X-AEO-Version")).toBe("1.0");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(await res.text()).toBe("# Post 1\n\nBody.");
+  });
+
+  it("returns 404 for direct .md request when asset missing", async () => {
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(() => new Response("html")),
+      fetchAsset,
+    });
+    const req = new Request("https://acme.test/missing.md");
+    const res = await middleware(req, makeCtx());
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("createAEOMiddleware — trailing slash", () => {
+  const fetchAsset = makeAssets({});
+
+  it("redirects /path/ → /path with 301 by default", async () => {
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(() => new Response("ok")),
+      fetchAsset,
+    });
+    const req = new Request("https://acme.test/blog/");
+    const res = await middleware(req, makeCtx());
+    expect(res.status).toBe(301);
+    expect(res.headers.get("location")).toBe("https://acme.test/blog");
+  });
+
+  it("preserves trailing slash with mode=preserve", async () => {
+    const upstream = vi.fn(
+      (_req: Request) => new Response("ok", { headers: { "Content-Type": "text/html" } }),
+    );
+    const middleware = createAEOMiddleware({
+      upstream: async (req) => upstream(req),
+      fetchAsset,
+      trailingSlash: "preserve",
+    });
+    const req = new Request("https://acme.test/blog/");
+    const res = await middleware(req, makeCtx());
+    expect(res.status).toBe(200);
+    expect(upstream).toHaveBeenCalledOnce();
+  });
+
+  it("redirects /path → /path/ with mode=always", async () => {
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(() => new Response("ok")),
+      fetchAsset,
+      trailingSlash: "always",
+    });
+    const req = new Request("https://acme.test/blog");
+    const res = await middleware(req, makeCtx());
+    expect(res.status).toBe(301);
+    expect(res.headers.get("location")).toBe("https://acme.test/blog/");
+  });
+});
+
+describe("createAEOMiddleware — redirects", () => {
+  let fetchAsset: AssetFetcher;
+  beforeEach(() => {
+    fetchAsset = makeAssets({ "/new-path.md": "# New\n\nMoved." });
+  });
+
+  it("follows internal redirect for AI bot to canonical .md", async () => {
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(() => new Response("html")),
+      fetchAsset,
+      redirects: { internal: { "/old-path": "/new-path" } },
+    });
+    const req = new Request("https://acme.test/old-path", {
+      headers: { "user-agent": "GPTBot/1.0" },
+    });
+    const res = await middleware(req, makeCtx());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-redirect-from")).toBe("/old-path");
+    expect(res.headers.get("x-redirect-to")).toBe("/new-path");
+    expect(await res.text()).toContain("# New");
+  });
+
+  it("returns markdown notice for external redirect", async () => {
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(() => new Response("html")),
+      fetchAsset,
+      redirects: { external: { "/login": "https://app.example.com" } },
+    });
+    const req = new Request("https://acme.test/login", {
+      headers: { "user-agent": "GPTBot/1.0" },
+    });
+    const res = await middleware(req, makeCtx());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/markdown; charset=utf-8");
+    expect(res.headers.get("x-redirect-to")).toBe("https://app.example.com");
+    expect(await res.text()).toContain("https://app.example.com");
+  });
+});
+
+describe("createAEOMiddleware — skip rules", () => {
+  const fetchAsset = makeAssets({});
+
+  it("skips /api/ paths entirely", async () => {
+    const upstream = vi.fn((_req: Request) => new Response("api"));
+    const middleware = createAEOMiddleware({
+      upstream: async (req) => upstream(req),
+      fetchAsset,
+    });
+    const req = new Request("https://acme.test/api/foo", {
+      headers: { "user-agent": "GPTBot/1.0" },
+    });
+    const res = await middleware(req, makeCtx());
+    expect(upstream).toHaveBeenCalledOnce();
+    expect(res.status).toBe(200);
+  });
+
+  it("skips asset extensions", async () => {
+    const upstream = vi.fn(
+      (_req: Request) => new Response(".css", { headers: { "Content-Type": "text/css" } }),
+    );
+    const middleware = createAEOMiddleware({
+      upstream: async (req) => upstream(req),
+      fetchAsset,
+    });
+    const req = new Request("https://acme.test/style.css", {
+      headers: { "user-agent": "GPTBot/1.0" },
+    });
+    await middleware(req, makeCtx());
+    expect(upstream).toHaveBeenCalledOnce();
+  });
+
+  it("does not inject Link header on non-html responses", async () => {
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(
+        () => new Response("{}", { headers: { "Content-Type": "application/json" } }),
+      ),
+      fetchAsset,
+    });
+    const req = new Request("https://acme.test/data");
+    const res = await middleware(req, makeCtx());
+    expect(res.headers.get("link")).toBeNull();
+  });
+});
+
+describe("createAEOMiddleware — analytics", () => {
+  it("calls onAIRequest on hit", async () => {
+    const onAIRequest = vi.fn();
+    const fetchAsset = makeAssets({ "/p.md": "# p" });
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(() => new Response("html")),
+      fetchAsset,
+      analytics: { onAIRequest },
+    });
+    await middleware(
+      new Request("https://acme.test/p", { headers: { "user-agent": "GPTBot/1.0" } }),
+      makeCtx(),
+    );
+    expect(onAIRequest).toHaveBeenCalledOnce();
+    const info = onAIRequest.mock.calls[0]?.[0];
+    expect(info.botName).toBe("GPTBot");
+    expect(info.cacheStatus).toBe("hit");
+  });
+
+  it("calls onMiss on cache miss", async () => {
+    const onMiss = vi.fn();
+    const fetchAsset = makeAssets({});
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(() => new Response("404", { status: 404 })),
+      fetchAsset,
+      analytics: { onMiss },
+    });
+    await middleware(
+      new Request("https://acme.test/q", { headers: { "user-agent": "GPTBot/1.0" } }),
+      makeCtx(),
+    );
+    expect(onMiss).toHaveBeenCalledOnce();
+  });
+
+  it("calls onAIRequest without context (no waitUntil)", async () => {
+    const onAIRequest = vi.fn();
+    const fetchAsset = makeAssets({ "/p.md": "# p" });
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(() => new Response("html")),
+      fetchAsset,
+      analytics: { onAIRequest },
+    });
+    await middleware(
+      new Request("https://acme.test/p", { headers: { "user-agent": "GPTBot/1.0" } }),
+    );
+    expect(onAIRequest).toHaveBeenCalledOnce();
+  });
+});
+
+describe("createAEOMiddleware — Link header injection", () => {
+  const fetchAsset = makeAssets({});
+
+  it("preserves existing Link header values", async () => {
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(
+        () =>
+          new Response("<html></html>", {
+            headers: {
+              "Content-Type": "text/html",
+              Link: "</style.css>; rel=preload; as=style",
+            },
+          }),
+      ),
+      fetchAsset,
+    });
+    const res = await middleware(new Request("https://acme.test/page"), makeCtx());
+    const link = res.headers.get("link") ?? "";
+    expect(link).toContain("</style.css>; rel=preload; as=style");
+    expect(link).toContain('</page.md>; rel="alternate"; type="text/markdown"');
+  });
+
+  it("can be disabled via enableLinkHeader=false", async () => {
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(
+        () => new Response("<html></html>", { headers: { "Content-Type": "text/html" } }),
+      ),
+      fetchAsset,
+      enableLinkHeader: false,
+    });
+    const res = await middleware(new Request("https://acme.test/page"), makeCtx());
+    expect(res.headers.get("link")).toBeNull();
+  });
+});
+
+describe("createAEOMiddleware — edge cases", () => {
+  it("handles fetchAsset throwing an error gracefully", async () => {
+    const fetchAsset: AssetFetcher = async () => {
+      throw new Error("network error");
+    };
+    const upstream = vi.fn(
+      (_req: Request) => new Response("html", { headers: { "Content-Type": "text/html" } }),
+    );
+    const middleware = createAEOMiddleware({
+      upstream: async (req) => upstream(req),
+      fetchAsset,
+    });
+    const req = new Request("https://acme.test/blog/post", {
+      headers: { "user-agent": "GPTBot/1.0" },
+    });
+    const res = await middleware(req, makeCtx());
+    expect(upstream).toHaveBeenCalledOnce();
+    expect(res.status).toBe(200);
+  });
+
+  it("handles root path .md request", async () => {
+    const fetchAsset = makeAssets({ "/index.md": "# Root" });
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(() => new Response("html")),
+      fetchAsset,
+    });
+    const req = new Request("https://acme.test/", {
+      headers: { "user-agent": "GPTBot/1.0" },
+    });
+    const res = await middleware(req, makeCtx());
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("# Root");
+  });
+
+  it("does not redirect root path with trailing slash in never mode", async () => {
+    const fetchAsset = makeAssets({ "/index.md": "# Root" });
+    const upstream = vi.fn(
+      (_req: Request) => new Response("html", { headers: { "Content-Type": "text/html" } }),
+    );
+    const middleware = createAEOMiddleware({
+      upstream: async (req) => upstream(req),
+      fetchAsset,
+      trailingSlash: "never",
+    });
+    const req = new Request("https://acme.test/");
+    const res = await middleware(req, makeCtx());
+    expect(res.status).not.toBe(301);
+  });
+
+  it("skips paths matching custom prefixes", async () => {
+    const upstream = vi.fn((_req: Request) => new Response("ok"));
+    const middleware = createAEOMiddleware({
+      upstream: async (req) => upstream(req),
+      fetchAsset: makeAssets({}),
+      skip: { prefixes: ["/internal"] },
+    });
+    const req = new Request("https://acme.test/internal/page", {
+      headers: { "user-agent": "GPTBot/1.0" },
+    });
+    const res = await middleware(req, makeCtx());
+    expect(upstream).toHaveBeenCalledOnce();
+    expect(res.status).toBe(200);
+  });
+
+  it("skips paths matching custom extensions", async () => {
+    const upstream = vi.fn(
+      (_req: Request) => new Response("data", { headers: { "Content-Type": "application/xml" } }),
+    );
+    const middleware = createAEOMiddleware({
+      upstream: async (req) => upstream(req),
+      fetchAsset: makeAssets({}),
+      skip: { extensions: [".xml"] },
+    });
+    const req = new Request("https://acme.test/feed.xml", {
+      headers: { "user-agent": "GPTBot/1.0" },
+    });
+    const res = await middleware(req, makeCtx());
+    expect(upstream).toHaveBeenCalledOnce();
+  });
+});
+
+describe("createAEOMiddleware — subrequest detection", () => {
+  it("returns passthrough response for subrequest header", async () => {
+    const fetchAsset = makeAssets({});
+    const upstream = vi.fn((_req: Request) => new Response("should-not-be-called"));
+    const middleware = createAEOMiddleware({
+      upstream: async (req) => upstream(req),
+      fetchAsset,
+    });
+    const req = new Request("https://acme.test/blog/post", {
+      headers: { "x-dualmark-subrequest": "1" },
+    });
+    const res = await middleware(req, makeCtx());
+    // NextResponse.next() is available → returns 200 passthrough
+    expect(res.status).toBe(200);
+    expect(upstream).not.toHaveBeenCalled();
+  });
+});

--- a/packages/vercel/test/middleware.test.ts
+++ b/packages/vercel/test/middleware.test.ts
@@ -327,6 +327,23 @@ describe("createAEOMiddleware — hooks", () => {
     expect(onMiss).toHaveBeenCalledOnce();
   });
 
+  it("does not call onAIRequest on a cache miss", async () => {
+    const onAIRequest = vi.fn();
+    const onMiss = vi.fn();
+    const fetchAsset = makeAssets({});
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(() => new Response("404", { status: 404 })),
+      fetchAsset,
+      hooks: { onAIRequest, onMiss },
+    });
+    await middleware(
+      new Request("https://acme.test/q", { headers: { "user-agent": "GPTBot/1.0" } }),
+      makeCtx(),
+    );
+    expect(onMiss).toHaveBeenCalledOnce();
+    expect(onAIRequest).not.toHaveBeenCalled();
+  });
+
   it("calls onAIRequest without context (no waitUntil)", async () => {
     const onAIRequest = vi.fn();
     const fetchAsset = makeAssets({ "/p.md": "# p" });

--- a/packages/vercel/test/middleware.test.ts
+++ b/packages/vercel/test/middleware.test.ts
@@ -293,14 +293,14 @@ describe("createAEOMiddleware — skip rules", () => {
   });
 });
 
-describe("createAEOMiddleware — analytics", () => {
+describe("createAEOMiddleware — hooks", () => {
   it("calls onAIRequest on hit", async () => {
     const onAIRequest = vi.fn();
     const fetchAsset = makeAssets({ "/p.md": "# p" });
     const middleware = createAEOMiddleware({
       upstream: makeUpstream(() => new Response("html")),
       fetchAsset,
-      analytics: { onAIRequest },
+      hooks: { onAIRequest },
     });
     await middleware(
       new Request("https://acme.test/p", { headers: { "user-agent": "GPTBot/1.0" } }),
@@ -318,7 +318,7 @@ describe("createAEOMiddleware — analytics", () => {
     const middleware = createAEOMiddleware({
       upstream: makeUpstream(() => new Response("404", { status: 404 })),
       fetchAsset,
-      analytics: { onMiss },
+      hooks: { onMiss },
     });
     await middleware(
       new Request("https://acme.test/q", { headers: { "user-agent": "GPTBot/1.0" } }),
@@ -333,7 +333,7 @@ describe("createAEOMiddleware — analytics", () => {
     const middleware = createAEOMiddleware({
       upstream: makeUpstream(() => new Response("html")),
       fetchAsset,
-      analytics: { onAIRequest },
+      hooks: { onAIRequest },
     });
     await middleware(
       new Request("https://acme.test/p", { headers: { "user-agent": "GPTBot/1.0" } }),

--- a/packages/vercel/tsconfig.json
+++ b/packages/vercel/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/packages/vercel/tsup.config.ts
+++ b/packages/vercel/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  splitting: false,
+  treeshake: true,
+  target: "es2022",
+  external: ["@dualmark/core", "next/server"],
+});


### PR DESCRIPTION
Closes #8.

## Summary

New package `@dualmark/vercel` with `createAEOMiddleware()` for Vercel Edge Middleware. Serves markdown twins to AI bots at the edge with no changes to the existing site. Uses Web Fetch API only (no Node APIs) and includes subrequest detection to prevent infinite fetch() loops that occur when Vercel Edge Middleware re-triggers for same-origin requests.

## Changes

- `packages/vercel/` adapter with createAEOMiddleware({ upstream, trailingSlash, hooks })
- Subrequest detection via x-dualmark-subrequest header
- Dynamic import of next/server with module-level caching
- Header mutation with clone fallback for immutable responses
- Optional lifecycle hooks (onAIRequest / onMiss) with waitUntil support
- 27 tests covering markdown serving, trailing slash, redirects, skip rules, hooks, Link header injection, edge cases, subrequest detection
- `examples/vercel-edge-full/` Next.js reference app with proxy.ts
- Changeset: @dualmark/vercel minor

## Acceptance criteria from #8

- [x] New package `packages/vercel`
- [x] Export `createAEOMiddleware({ upstream, trailingSlash, hooks })`
- [x] Uses Vercel Edge runtime (Web Fetch API), not Node
- [x] Optional Vercel Analytics / OpenTelemetry hooks
- [x] `examples/vercel-edge-full` scoring >= 120/125 (120/125 confirmed)
- [x] Cold start under 50ms (0.03ms measured locally)
- [x] Tests cover same negotiation scenarios as cloudflare adapter

## Type

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change
- [ ] Spec change (requires bump in AEO_SPEC_VERSION)
- [ ] Docs / examples / tooling only

## Verification

- [x] `bun run build` passes (12/12 turbo tasks)
- [x] `bun run test` passes (all packages green)
- [x] `bun run typecheck` passes
- [x] `dualmark verify` against example: 120/125

## Changeset

- [x] Added a changeset (`bun run changeset`) for any package with a user-visible change