### PR TITLE
fix(ci): add --skip-negotiation to astro-blog conformance step

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -31,7 +31,7 @@ jobs:
           ./node_modules/.bin/astro dev --port 4321 &
           DEV_PID=$!
           sleep 10
-          node ../../packages/cli/dist/cli.js verify http://localhost:4321/blog/hello-world
+          node ../../packages/cli/dist/cli.js verify http://localhost:4321/blog/hello-world --skip-negotiation
           kill $DEV_PID
 
   astro-cloudflare-full:


### PR DESCRIPTION
## Summary

Add "--skip-negotiation" to astro-blog conformance step in CI. Astro dev cannot perform content negotiation (the dualmark middleware is bypassed under HMR), so negotiation.acceptHeader (required) always fails. Under #35's new strict exit-code semantic, that pushes the step's exit code to 1 and fails CI on every main push.

## Changes

<!-- bullets, focused on what + why -->

- Add --skip-negotiation to fix the failing CI

## Type

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Spec change (requires bump in `AEO_SPEC_VERSION`)
- [ ] Docs / examples / tooling only

## Verification

- [ ] `bun run build` passes
- [ ] `bun run test` passes
- [ ] `bun run typecheck` passes
- [ ] If touching examples: ran `dualmark verify` against the example end-to-end
- [ ] If touching `/spec/`: ran `bun run --filter dualmark-docs sync-spec` and committed the mirror

## Changeset

- [ ] Added a changeset (`bun run changeset`) for any package with a user-visible change
