### PR TITLE
feat: add pluggable token estimator with inline tokenizer option

### DIFF
--- a/.changeset/warm-tigers-glow.md
+++ b/.changeset/warm-tigers-glow.md
@@ -1,0 +1,16 @@
+---
+"@dualmark/core": minor
+"@dualmark/astro": minor
+"@dualmark/cloudflare": minor
+"@dualmark/deno": minor
+"@dualmark/nextjs": minor
+"@dualmark/sveltekit": minor
+"@dualmark/vercel": minor
+---
+
+Add pluggable token estimator with inline `tokenizer` option
+
+- `estimateTokens(text, { tokenizer })` accepts an inline override function
+- Export `TokenEstimator` type, `setTokenEstimator`, and `resetTokenEstimator` from core
+- Add `tokenizer` option to all adapter configs: Astro, Cloudflare, Deno, Next.js, SvelteKit
+- Astro adapter supports both function tokenizers and module-path strings (e.g. `"./src/aeo-tokenizer.ts"`) for tokenizers that close over external state like js-tiktoken

--- a/apps/docs/content/docs/custom-tokenizer.mdx
+++ b/apps/docs/content/docs/custom-tokenizer.mdx
@@ -1,0 +1,182 @@
+---
+title: Custom tokenizer
+description: Swap the default word counter for js-tiktoken or any BPE tokenizer.
+---
+
+By default Dualmark counts tokens with a whitespace-split word counter. For accurate BPE counts (e.g. matching OpenAI model billing), plug in a custom tokenizer.
+
+## Quick start with js-tiktoken
+
+### 1. Install js-tiktoken
+
+<Tabs items={["bun", "npm", "yarn"]}>
+<Tab value="bun">
+```bash
+bun add js-tiktoken
+```
+</Tab>
+<Tab value="npm">
+```bash
+npm install js-tiktoken
+```
+</Tab>
+<Tab value="yarn">
+```bash
+yarn add js-tiktoken
+```
+</Tab>
+</Tabs>
+
+### 2. Create a tokenizer module
+
+```ts title="src/aeo-tokenizer.ts"
+import { encodingForModel } from "js-tiktoken";
+
+const encoder = encodingForModel("gpt-4o");
+
+export default function tokenizer(text: string): number {
+  return encoder.encode(text).length;
+}
+```
+
+Export a default function with the signature `(text: string) => number`.
+
+### 3. Wire it up
+
+Config varies by adapter:
+
+<Tabs items={["Astro", "Next.js", "SvelteKit", "Vercel", "Cloudflare", "Deno"]}>
+<Tab value="Astro">
+
+Astro code-generates route files at build time, so closures can't be serialized. Pass a **module path** instead:
+
+```js title="astro.config.mjs"
+import dualmark from "@dualmark/astro";
+
+export default defineConfig({
+  integrations: [
+    dualmark({
+      siteUrl: "https://example.com",
+      collections: { blog: { converter: "blog" } },
+      tokenizer: "./src/aeo-tokenizer.ts",
+    }),
+  ],
+});
+```
+
+The generated routes will `import` your module directly — no serialization issues with closed-over encoders.
+
+> For simple, self-contained arrow functions that don't close over external state, you can still pass a function directly:
+> ```js
+> tokenizer: (text) => text.split(/\s+/).length * 1.3
+> ```
+
+</Tab>
+<Tab value="Next.js">
+
+```ts title="dualmark.config.ts"
+import type { DualmarkNextConfig } from "@dualmark/nextjs";
+import tokenizer from "./src/aeo-tokenizer";
+
+export const dualmarkConfig: DualmarkNextConfig = {
+  siteUrl: "https://example.com",
+  collections: { blog: { converter: "blog", getEntries: () => [] } },
+  tokenizer,
+};
+```
+
+</Tab>
+<Tab value="SvelteKit">
+
+```ts title="src/dualmark.config.ts"
+import type { DualmarkSvelteKitConfig } from "@dualmark/sveltekit";
+import tokenizer from "./aeo-tokenizer";
+
+const config: DualmarkSvelteKitConfig = {
+  siteUrl: "https://example.com",
+  collections: { blog: { converter: "blog", getEntries: () => [] } },
+  tokenizer,
+};
+
+export default config;
+```
+
+</Tab>
+<Tab value="Vercel">
+
+```ts title="middleware.ts"
+import { createAEOMiddleware } from "@dualmark/vercel";
+import tokenizer from "./src/aeo-tokenizer";
+
+export default createAEOMiddleware({
+  upstream: (req) => fetch(req),
+  fetchAsset: (url, init) => fetch(url, init),
+  tokenizer,
+});
+```
+
+</Tab>
+<Tab value="Cloudflare">
+
+```ts title="src/index.ts"
+import { createAEOWorker } from "@dualmark/cloudflare";
+import tokenizer from "./aeo-tokenizer";
+
+export default createAEOWorker({
+  upstream: { fetch: (req, env, ctx) => env.ASSETS.fetch(req) },
+  tokenizer,
+});
+```
+
+</Tab>
+<Tab value="Deno">
+
+```ts title="main.ts"
+import { createAEOHandler } from "@dualmark/deno";
+import tokenizer from "./aeo-tokenizer.ts";
+
+const handler = createAEOHandler({
+  upstream: (req) => new Response("upstream"),
+  tokenizer,
+});
+
+Deno.serve(handler);
+```
+
+</Tab>
+</Tabs>
+
+## How it works
+
+The `tokenizer` function is called by `estimateTokens()` in `@dualmark/core`. The returned count is set as the `X-Markdown-Tokens` response header on every markdown response.
+
+```
+X-Markdown-Tokens: 1847
+```
+
+AI clients use this header for context-window budget planning. With js-tiktoken the count matches the model's actual BPE encoding.
+
+## Global override (advanced)
+
+For edge cases where you can't pass `tokenizer` through config (e.g. custom middleware), you can set a global default:
+
+```ts
+import { setTokenEstimator, resetTokenEstimator } from "@dualmark/core";
+import { encodingForModel } from "js-tiktoken";
+
+const enc = encodingForModel("gpt-4o");
+setTokenEstimator((text) => enc.encode(text).length);
+
+// Later, to restore the default:
+resetTokenEstimator();
+```
+
+The inline `tokenizer` option in each adapter config always takes precedence over the global override.
+
+## TokenEstimator type
+
+```ts
+type TokenEstimator = (text: string) => number;
+```
+
+Any function matching this signature works — `gpt-tokenizer`, `tiktoken-node`, or a hand-rolled counter.

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -4,6 +4,7 @@
     "---[Rocket]Get started---",
     "quickstart",
     "concepts",
+    "custom-tokenizer",
     "---[CirclePlay]CI & automation---",
     "ci",
     "---[Plug]Integrate---",

--- a/apps/docs/content/docs/packages/core.mdx
+++ b/apps/docs/content/docs/packages/core.mdx
@@ -92,10 +92,23 @@ Both helpers are idempotent on already-`.md` inputs.
 ## Token estimation
 
 ```ts
-import { estimateTokens } from "@dualmark/core";
+import { estimateTokens, setTokenEstimator, resetTokenEstimator } from "@dualmark/core";
 ```
 
-Whitespace-split counter — fast, zero-dep, good enough for `X-Markdown-Tokens`.
+### `estimateTokens(text, options?): number`
+
+Returns the estimated token count. By default uses a whitespace-split word counter.
+
+```ts
+estimateTokens("hello world");                        // → 2  (default)
+estimateTokens("hello world", { tokenizer: t => t.length }); // → 11  (custom)
+```
+
+### `setTokenEstimator(fn)` / `resetTokenEstimator()`
+
+Set or reset the global default estimator. The inline `tokenizer` option always takes precedence.
+
+See [Custom tokenizer](/docs/custom-tokenizer) for js-tiktoken setup.
 
 ## Text utilities
 

--- a/packages/astro/src/config-validation.ts
+++ b/packages/astro/src/config-validation.ts
@@ -88,5 +88,6 @@ export function resolveConfig(
       cacheControl: input.headers?.cacheControl ?? "public, max-age=3600",
       noindex: input.headers?.noindex !== false,
     },
+    tokenizer: input.tokenizer,
   };
 }

--- a/packages/astro/src/config-validation.ts
+++ b/packages/astro/src/config-validation.ts
@@ -75,6 +75,21 @@ export function resolveConfig(
       );
     }
   }
+  if (input.tokenizer !== undefined && typeof input.tokenizer === "string") {
+    if (!input.tokenizer) {
+      throw new DualmarkConfigError(
+        formatError("tokenizer module path must not be empty", filePath),
+      );
+    }
+    if (!input.tokenizer.startsWith("./") && !input.tokenizer.startsWith("../")) {
+      throw new DualmarkConfigError(
+        formatError(
+          `tokenizer module path must be a relative path starting with './' or '../' (got '${input.tokenizer}')`,
+          filePath,
+        ),
+      );
+    }
+  }
   return {
     siteUrl: input.siteUrl,
     collections,

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -12,5 +12,6 @@ export type {
   StaticPageConfig,
   ParameterizedRouteConfig,
   SlugStrategy,
+  TokenEstimator,
 } from "./types.js";
 export { resolveBuiltInConverter, type BuiltInConverterName } from "./converter-registry.js";

--- a/packages/astro/src/integration.ts
+++ b/packages/astro/src/integration.ts
@@ -80,14 +80,26 @@ export function createDualmarkIntegration(input: DualmarkAstroConfig): AstroInte
         if (!existsSync(generatedDir)) mkdirSync(generatedDir, { recursive: true });
 
         const hasTokenizer = !!resolved.tokenizer;
-        if (hasTokenizer) {
+        const tokenizerIsModulePath = typeof resolved.tokenizer === "string";
+        if (hasTokenizer && !tokenizerIsModulePath) {
           writeFileSync(
             join(generatedDir, "tokenizer.mjs"),
-            `export default ${resolved.tokenizer!.toString()};\n`,
+            `export default ${(resolved.tokenizer as Function).toString()};\n`,
             "utf8",
           );
         }
-        const tokenizerImport = hasTokenizer ? `import tokenizer from "./tokenizer.mjs";\n` : "";
+
+        let tokenizerImport = "";
+        if (hasTokenizer) {
+          if (tokenizerIsModulePath) {
+            const absTokenizerPath = join(root, resolved.tokenizer as string);
+            const importPath = rel(generatedDir, absTokenizerPath);
+            const importSpecifier = importPath.startsWith("../") ? importPath : `./${importPath}`;
+            tokenizerImport = `import tokenizer from "${importSpecifier}";\n`;
+          } else {
+            tokenizerImport = `import tokenizer from "./tokenizer.mjs";\n`;
+          }
+        }
         const responseOpts = hasTokenizer
           ? `{ cacheControl: dualmarkConfig.cacheControl, noindex: dualmarkConfig.noindex, tokenizer }`
           : `{ cacheControl: dualmarkConfig.cacheControl, noindex: dualmarkConfig.noindex }`;

--- a/packages/astro/src/integration.ts
+++ b/packages/astro/src/integration.ts
@@ -79,6 +79,19 @@ export function createDualmarkIntegration(input: DualmarkAstroConfig): AstroInte
         const generatedDir = join(root, "node_modules", GENERATED_DIR_NAME);
         if (!existsSync(generatedDir)) mkdirSync(generatedDir, { recursive: true });
 
+        const hasTokenizer = !!resolved.tokenizer;
+        if (hasTokenizer) {
+          writeFileSync(
+            join(generatedDir, "tokenizer.mjs"),
+            `export default ${resolved.tokenizer!.toString()};\n`,
+            "utf8",
+          );
+        }
+        const tokenizerImport = hasTokenizer ? `import tokenizer from "./tokenizer.mjs";\n` : "";
+        const responseOpts = hasTokenizer
+          ? `{ cacheControl: dualmarkConfig.cacheControl, noindex: dualmarkConfig.noindex, tokenizer }`
+          : `{ cacheControl: dualmarkConfig.cacheControl, noindex: dualmarkConfig.noindex }`;
+
         writeFileSync(
           join(generatedDir, "config.mjs"),
           `export default ${JSON.stringify(
@@ -111,7 +124,7 @@ export function createDualmarkIntegration(input: DualmarkAstroConfig): AstroInte
 import { makeCollectionDetailEndpoint } from "@dualmark/astro/endpoints/collection";
 import { getCollection } from "astro:content";
 import dualmarkConfig from "./config.mjs";
-
+${tokenizerImport}
 const converter = resolveBuiltInConverter({
   name: ${JSON.stringify(c.converter)},
   collectionName: ${JSON.stringify(collectionName)},
@@ -122,7 +135,7 @@ const endpoint = makeCollectionDetailEndpoint({
   collectionName: ${JSON.stringify(collectionName)},
   converter,
   getCollection: (name, filter) => getCollection(name, filter),
-  responseOptions: { cacheControl: dualmarkConfig.cacheControl, noindex: dualmarkConfig.noindex },
+  responseOptions: ${responseOpts},
 });
 
 export const getStaticPaths = endpoint.getStaticPaths;
@@ -132,7 +145,7 @@ export const GET = endpoint.GET;
           const listingSource = `import { makeListingEndpoint } from "@dualmark/astro/endpoints/listing";
 import { getCollection } from "astro:content";
 import dualmarkConfig from "./config.mjs";
-
+${tokenizerImport}
 const endpoint = makeListingEndpoint({
   collectionName: ${JSON.stringify(collectionName)},
   siteUrl: dualmarkConfig.siteUrl,
@@ -140,7 +153,7 @@ const endpoint = makeListingEndpoint({
   title: ${JSON.stringify(c.listingMetadata?.title ?? collectionName)},
   description: ${JSON.stringify(c.listingMetadata?.description ?? `All ${collectionName} entries.`)},
   getCollection: (name, filter) => getCollection(name, filter),
-  responseOptions: { cacheControl: dualmarkConfig.cacheControl, noindex: dualmarkConfig.noindex },
+  responseOptions: ${responseOpts},
 });
 
 export const GET = endpoint.GET;
@@ -170,10 +183,10 @@ export const GET = endpoint.GET;
           const source = `import { makeStaticEndpoint } from "@dualmark/astro/endpoints/static";
 import dualmarkConfig from "./config.mjs";
 import render from "./${rel(generatedDir, renderModulePath)}";
-
+${tokenizerImport}
 const endpoint = makeStaticEndpoint({
   render,
-  responseOptions: { cacheControl: dualmarkConfig.cacheControl, noindex: dualmarkConfig.noindex },
+  responseOptions: ${responseOpts},
 });
 
 export const GET = endpoint.GET;
@@ -199,11 +212,11 @@ export const GET = endpoint.GET;
 import dualmarkConfig from "./config.mjs";
 import render from "./${rel(generatedDir, renderModulePath)}";
 import getStaticPaths from "./${rel(generatedDir, pathsModulePath)}";
-
+${tokenizerImport}
 const endpoint = makeParameterizedEndpoint({
   getStaticPaths: () => getStaticPaths(),
   render,
-  responseOptions: { cacheControl: dualmarkConfig.cacheControl, noindex: dualmarkConfig.noindex },
+  responseOptions: ${responseOpts},
 });
 
 export const getStaticPaths = endpoint.getStaticPaths;

--- a/packages/astro/src/types.ts
+++ b/packages/astro/src/types.ts
@@ -1,5 +1,6 @@
 import type { Converter, CollectionEntry } from "@dualmark/converters";
-import type { LlmsTxtSection } from "@dualmark/core";
+import type { LlmsTxtSection, TokenEstimator } from "@dualmark/core";
+export type { TokenEstimator } from "@dualmark/core";
 
 export type SlugStrategy = "catch-all" | "single";
 
@@ -45,6 +46,8 @@ export interface DualmarkAstroConfig {
     cacheControl?: string;
     noindex?: boolean;
   };
+  /** Custom token estimator. Overrides the default whitespace-word counter. */
+  tokenizer?: TokenEstimator;
 }
 
 export interface ResolvedDualmarkConfig extends DualmarkAstroConfig {

--- a/packages/astro/src/types.ts
+++ b/packages/astro/src/types.ts
@@ -46,8 +46,12 @@ export interface DualmarkAstroConfig {
     cacheControl?: string;
     noindex?: boolean;
   };
-  /** Custom token estimator. Overrides the default whitespace-word counter. */
-  tokenizer?: TokenEstimator;
+  /**
+   * Custom token estimator. Overrides the default whitespace-word counter.
+   * Pass a function, or a module path (e.g. `"./src/aeo-tokenizer.ts"`)
+   * for tokenizers that close over external state like js-tiktoken.
+   */
+  tokenizer?: TokenEstimator | string;
 }
 
 export interface ResolvedDualmarkConfig extends DualmarkAstroConfig {

--- a/packages/astro/test/config-validation.test.ts
+++ b/packages/astro/test/config-validation.test.ts
@@ -100,4 +100,46 @@ describe("resolveConfig", () => {
       /^\[\/abs\/astro\.config\.mjs\] Dualmark config error: Config must be an object$/,
     );
   });
+
+  it("accepts a function tokenizer", () => {
+    const out = resolveConfig({
+      siteUrl: "https://example.com",
+      tokenizer: (t: string) => t.length,
+    });
+    expect(typeof out.tokenizer).toBe("function");
+  });
+
+  it("accepts a string tokenizer module path", () => {
+    const out = resolveConfig({
+      siteUrl: "https://example.com",
+      tokenizer: "./src/aeo-tokenizer.ts",
+    });
+    expect(out.tokenizer).toBe("./src/aeo-tokenizer.ts");
+  });
+
+  it("accepts a ../ relative tokenizer module path", () => {
+    const out = resolveConfig({
+      siteUrl: "https://example.com",
+      tokenizer: "../shared/tokenizer.ts",
+    });
+    expect(out.tokenizer).toBe("../shared/tokenizer.ts");
+  });
+
+  it("rejects absolute tokenizer module path", () => {
+    expect(() =>
+      resolveConfig({
+        siteUrl: "https://example.com",
+        tokenizer: "/abs/tokenizer.ts" as never,
+      }),
+    ).toThrow(/must be a relative path/);
+  });
+
+  it("rejects bare module tokenizer path", () => {
+    expect(() =>
+      resolveConfig({
+        siteUrl: "https://example.com",
+        tokenizer: "my-tokenizer" as never,
+      }),
+    ).toThrow(/must be a relative path/);
+  });
 });

--- a/packages/astro/test/integration.test.ts
+++ b/packages/astro/test/integration.test.ts
@@ -170,6 +170,55 @@ describe("createDualmarkIntegration — astro:config:setup", () => {
     await integ.hooks["astro:config:setup"](ctx);
     expect(ctx.logger.warn).toHaveBeenCalled();
   });
+
+  it("writes tokenizer.mjs when tokenizer is a function", async () => {
+    const integ = createDualmarkIntegration({
+      siteUrl: "https://example.com",
+      collections: { blog: { converter: "blog" } },
+      tokenizer: (t: string) => t.length,
+    });
+    const ctx = makeFakeContext(tmpRoot);
+    await integ.hooks["astro:config:setup"](ctx);
+
+    const tokenizerPath = join(tmpRoot, "node_modules", ".dualmark-generated", "tokenizer.mjs");
+    expect(existsSync(tokenizerPath)).toBe(true);
+    const content = readFileSync(tokenizerPath, "utf8");
+    expect(content).toContain("export default");
+
+    // should import from ./tokenizer.mjs
+    const routeFile = ctx.injected[0];
+    const routeSource = readFileSync(
+      typeof routeFile!.entrypoint === "string" ? routeFile!.entrypoint : routeFile!.entrypoint.pathname,
+      "utf8",
+    );
+    expect(routeSource).toContain('import tokenizer from "./tokenizer.mjs"');
+    expect(routeSource).toContain("tokenizer");
+  });
+
+  it("uses direct import when tokenizer is a module path (string)", async () => {
+    const integ = createDualmarkIntegration({
+      siteUrl: "https://example.com",
+      collections: { blog: { converter: "blog" } },
+      tokenizer: "./src/aeo-tokenizer.ts",
+    });
+    const ctx = makeFakeContext(tmpRoot);
+    await integ.hooks["astro:config:setup"](ctx);
+
+    // should NOT write tokenizer.mjs
+    const tokenizerMjsPath = join(tmpRoot, "node_modules", ".dualmark-generated", "tokenizer.mjs");
+    expect(existsSync(tokenizerMjsPath)).toBe(false);
+
+
+    const routeFile = ctx.injected[0];
+    const routeSource = readFileSync(
+      typeof routeFile!.entrypoint === "string" ? routeFile!.entrypoint : routeFile!.entrypoint.pathname,
+      "utf8",
+    );
+    expect(routeSource).toContain("import tokenizer from");
+    expect(routeSource).toContain("aeo-tokenizer");
+    expect(routeSource).not.toContain("./tokenizer.mjs");
+    expect(routeSource).toContain("tokenizer");
+  });
 });
 
 describe("converter-registry resolveBuiltInConverter", () => {

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -10,4 +10,5 @@ export type {
   AIRequestInfo,
   MissInfo,
   TrailingSlashMode,
+  TokenEstimator,
 } from "./types.js";

--- a/packages/cloudflare/src/types.ts
+++ b/packages/cloudflare/src/types.ts
@@ -34,9 +34,10 @@ export type {
   AIRequestInfo,
   MissInfo,
   TrailingSlashMode,
+  TokenEstimator,
 } from "@dualmark/core";
 
-import type { AIRequestInfo, MissInfo, TrailingSlashMode } from "@dualmark/core";
+import type { AIRequestInfo, MissInfo, TrailingSlashMode, TokenEstimator } from "@dualmark/core";
 
 export interface CreateAEOWorkerOptions<Env extends MinimalEnv = MinimalEnv> {
   upstream: UpstreamWorker<Env>;
@@ -60,4 +61,5 @@ export interface CreateAEOWorkerOptions<Env extends MinimalEnv = MinimalEnv> {
     onMiss?: (info: MissInfo) => void | Promise<void>;
   };
   enableLinkHeader?: boolean;
+  tokenizer?: TokenEstimator;
 }

--- a/packages/cloudflare/src/types.ts
+++ b/packages/cloudflare/src/types.ts
@@ -61,5 +61,6 @@ export interface CreateAEOWorkerOptions<Env extends MinimalEnv = MinimalEnv> {
     onMiss?: (info: MissInfo) => void | Promise<void>;
   };
   enableLinkHeader?: boolean;
+  /** Custom token estimator. Overrides the default whitespace-word counter. */
   tokenizer?: TokenEstimator;
 }

--- a/packages/cloudflare/src/worker.ts
+++ b/packages/cloudflare/src/worker.ts
@@ -50,10 +50,11 @@ function normalizePath(pathname: string): string {
 function buildMarkdownHeaders(
   body: string,
   cacheControl: string,
+  tokenizer?: (text: string) => number,
   redirectFrom?: string,
   redirectTo?: string,
 ): Headers {
-  const tokens = estimateTokens(body);
+  const tokens = estimateTokens(body, { tokenizer });
   const headers = new Headers({
     "Content-Type": "text/markdown; charset=utf-8",
     "X-Content-Type-Options": "nosniff",
@@ -99,6 +100,7 @@ export function createAEOWorker<Env extends MinimalEnv = MinimalEnv>(
   const cacheControl = options.headers?.cacheControl ?? DEFAULT_CACHE_CONTROL;
   const analyticsBinding = options.analytics?.binding;
   const enableLinkHeader = options.enableLinkHeader !== false;
+  const tokenizer = options.tokenizer;
 
   const onAIRequest = options.hooks?.onAIRequest;
   const onMiss = options.hooks?.onMiss;
@@ -143,7 +145,7 @@ export function createAEOWorker<Env extends MinimalEnv = MinimalEnv>(
           const body = await assetResponse.text();
           return new Response(body, {
             status: 200,
-            headers: buildMarkdownHeaders(body, cacheControl),
+            headers: buildMarkdownHeaders(body, cacheControl, tokenizer),
           });
         }
         return assetResponse ?? new Response("Not Found", { status: 404 });
@@ -182,7 +184,7 @@ export function createAEOWorker<Env extends MinimalEnv = MinimalEnv>(
 
           if (assetResponse && assetResponse.ok) {
             const body = await assetResponse.text();
-            const tokens = estimateTokens(body);
+            const tokens = estimateTokens(body, { tokenizer });
             const info: AIRequestInfo = {
               url,
               botName: bot.name,
@@ -196,7 +198,7 @@ export function createAEOWorker<Env extends MinimalEnv = MinimalEnv>(
             if (onAIRequest) ctx.waitUntil(Promise.resolve(onAIRequest(info)));
             return new Response(body, {
               status: 200,
-              headers: buildMarkdownHeaders(body, cacheControl),
+              headers: buildMarkdownHeaders(body, cacheControl, tokenizer),
             });
           }
 
@@ -208,7 +210,7 @@ export function createAEOWorker<Env extends MinimalEnv = MinimalEnv>(
               const targetResp = await env.ASSETS.fetch(new URL(targetMd, url.origin));
               if (targetResp.ok) {
                 const body = await targetResp.text();
-                const tokens = estimateTokens(body);
+                const tokens = estimateTokens(body, { tokenizer });
                 const info: AIRequestInfo = {
                   url,
                   botName: bot.name,
@@ -222,7 +224,7 @@ export function createAEOWorker<Env extends MinimalEnv = MinimalEnv>(
                 if (onAIRequest) ctx.waitUntil(Promise.resolve(onAIRequest(info)));
                 return new Response(body, {
                   status: 200,
-                  headers: buildMarkdownHeaders(body, cacheControl, cleanPath, internalTarget),
+                  headers: buildMarkdownHeaders(body, cacheControl, tokenizer, cleanPath, internalTarget),
                 });
               }
             } catch {
@@ -233,7 +235,7 @@ export function createAEOWorker<Env extends MinimalEnv = MinimalEnv>(
           const externalTarget = externalRedirects[cleanPath];
           if (externalTarget) {
             const body = `# Redirect\n\nThis page has moved to an external location.\n\n- **Redirect**: [${externalTarget}](${externalTarget})\n`;
-            const tokens = estimateTokens(body);
+            const tokens = estimateTokens(body, { tokenizer });
             const info: AIRequestInfo = {
               url,
               botName: bot.name,
@@ -247,7 +249,7 @@ export function createAEOWorker<Env extends MinimalEnv = MinimalEnv>(
             if (onAIRequest) ctx.waitUntil(Promise.resolve(onAIRequest(info)));
             return new Response(body, {
               status: 200,
-              headers: buildMarkdownHeaders(body, cacheControl, cleanPath, externalTarget),
+              headers: buildMarkdownHeaders(body, cacheControl, tokenizer, cleanPath, externalTarget),
             });
           }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,13 @@ export {
   type ParsedMediaType,
 } from "./negotiation.js";
 
-export { estimateTokens } from "./tokens.js";
+export {
+  estimateTokens,
+  setTokenEstimator,
+  resetTokenEstimator,
+  type TokenEstimator,
+  type EstimateTokensOptions,
+} from "./tokens.js";
 
 export {
   normalizeUnicode,

--- a/packages/core/src/markdown.ts
+++ b/packages/core/src/markdown.ts
@@ -1,5 +1,5 @@
 import { normalizeUnicode } from "./text.js";
-import { estimateTokens } from "./tokens.js";
+import { estimateTokens, type TokenEstimator } from "./tokens.js";
 
 export interface MarkdownResponseOptions {
   cacheControl?: string;
@@ -8,6 +8,7 @@ export interface MarkdownResponseOptions {
   redirectTo?: string;
   extraHeaders?: HeadersInit;
   status?: number;
+  tokenizer?: TokenEstimator;
 }
 
 const DEFAULT_CACHE_CONTROL = "public, max-age=3600";
@@ -17,7 +18,7 @@ export function markdownResponse(
   options: MarkdownResponseOptions = {},
 ): Response {
   const normalized = normalizeUnicode(body);
-  const tokens = estimateTokens(normalized);
+  const tokens = estimateTokens(normalized, { tokenizer: options.tokenizer });
 
   const headers = new Headers({
     "Content-Type": "text/markdown; charset=utf-8",

--- a/packages/core/src/tokens.ts
+++ b/packages/core/src/tokens.ts
@@ -1,11 +1,16 @@
-type TokenEstimator = (text: string) => number;
+export type TokenEstimator = (text: string) => number;
+
+export interface EstimateTokensOptions {
+  tokenizer?: TokenEstimator;
+}
 
 const defaultEstimator: TokenEstimator = (text) => text.split(/\s+/).filter(Boolean).length;
 
 let currentEstimator: TokenEstimator = defaultEstimator;
 
-export function estimateTokens(text: string): number {
-  return currentEstimator(text);
+export function estimateTokens(text: string, options?: EstimateTokensOptions): number {
+  const fn = options?.tokenizer ?? currentEstimator;
+  return fn(text);
 }
 
 export function setTokenEstimator(fn: TokenEstimator): void {

--- a/packages/core/test/index.test.ts
+++ b/packages/core/test/index.test.ts
@@ -10,6 +10,8 @@ describe("@dualmark/core public surface", () => {
 
   it("exports token API", () => {
     expect(typeof core.estimateTokens).toBe("function");
+    expect(typeof core.setTokenEstimator).toBe("function");
+    expect(typeof core.resetTokenEstimator).toBe("function");
   });
 
   it("exports text API", () => {

--- a/packages/core/test/markdown.test.ts
+++ b/packages/core/test/markdown.test.ts
@@ -78,6 +78,12 @@ describe("markdownResponse", () => {
     const r = markdownResponse("# x", { status: 404 });
     expect(r.status).toBe(404);
   });
+
+  it("uses custom tokenizer for X-Markdown-Tokens when provided", () => {
+    const charCounter = (text: string) => text.length;
+    const r = markdownResponse("hello world", { tokenizer: charCounter });
+    expect(r.headers.get("x-markdown-tokens")).toBe("11");
+  });
 });
 
 describe("renderLinkAlternateHeader", () => {

--- a/packages/core/test/tokens.test.ts
+++ b/packages/core/test/tokens.test.ts
@@ -36,3 +36,31 @@ describe("setTokenEstimator / resetTokenEstimator", () => {
     expect(estimateTokens("hi")).toBe(1);
   });
 });
+
+describe("estimateTokens with inline tokenizer option", () => {
+  afterEach(() => resetTokenEstimator());
+
+  it("uses inline tokenizer when provided", () => {
+    const charCounter = (t: string) => t.length;
+    expect(estimateTokens("hello", { tokenizer: charCounter })).toBe(5);
+  });
+
+  it("inline tokenizer takes precedence over global setTokenEstimator", () => {
+    setTokenEstimator(() => 999);
+    const charCounter = (t: string) => t.length;
+    expect(estimateTokens("hi", { tokenizer: charCounter })).toBe(2);
+  });
+
+  it("falls back to global estimator when inline tokenizer is omitted", () => {
+    setTokenEstimator(() => 42);
+    expect(estimateTokens("anything")).toBe(42);
+  });
+
+  it("falls back to default when no inline tokenizer and no global override", () => {
+    expect(estimateTokens("one two three")).toBe(3);
+  });
+
+  it("handles empty options object", () => {
+    expect(estimateTokens("a b c", {})).toBe(3);
+  });
+});

--- a/packages/deno/src/handler.ts
+++ b/packages/deno/src/handler.ts
@@ -94,6 +94,7 @@ export function createAEOHandler(options: CreateAEOHandlerOptions): AEODenoHandl
   const trailingSlash = options.trailingSlash ?? "never";
   const cacheControl = options.headers?.cacheControl ?? DEFAULT_CACHE_CONTROL;
   const enableLinkHeader = options.enableLinkHeader !== false;
+  const tokenizer = options.tokenizer;
 
   const onAIRequest = options.hooks?.onAIRequest;
   const onMiss = options.hooks?.onMiss;
@@ -138,7 +139,7 @@ export function createAEOHandler(options: CreateAEOHandlerOptions): AEODenoHandl
       }
       if (assetResponse && assetResponse.ok) {
         const body = await assetResponse.text();
-        const tokens = estimateTokens(body);
+        const tokens = estimateTokens(body, { tokenizer });
         return new Response(body, {
           status: 200,
           headers: buildMarkdownHeaders(tokens, cacheControl),
@@ -186,7 +187,7 @@ export function createAEOHandler(options: CreateAEOHandlerOptions): AEODenoHandl
 
         if (assetResponse && assetResponse.ok) {
           const body = await assetResponse.text();
-          const tokens = estimateTokens(body);
+          const tokens = estimateTokens(body, { tokenizer });
           const aiInfo: AIRequestInfo = {
             url,
             botName: bot.name,
@@ -214,7 +215,7 @@ export function createAEOHandler(options: CreateAEOHandlerOptions): AEODenoHandl
             const targetResp = await options.upstream(targetReq, info);
             if (targetResp.ok) {
               const body = await targetResp.text();
-              const tokens = estimateTokens(body);
+              const tokens = estimateTokens(body, { tokenizer });
               const aiInfo: AIRequestInfo = {
                 url,
                 botName: bot.name,
@@ -238,7 +239,7 @@ export function createAEOHandler(options: CreateAEOHandlerOptions): AEODenoHandl
         const externalTarget = externalRedirects[cleanPath];
         if (externalTarget) {
           const body = `# Redirect\n\nThis page has moved to an external location.\n\n- **Redirect**: [${externalTarget}](${externalTarget})\n`;
-          const tokens = estimateTokens(body);
+          const tokens = estimateTokens(body, { tokenizer });
           const aiInfo: AIRequestInfo = {
             url,
             botName: bot.name,

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -7,4 +7,5 @@ export type {
   AIRequestInfo,
   MissInfo,
   TrailingSlashMode,
+  TokenEstimator,
 } from "./types.js";

--- a/packages/deno/src/types.ts
+++ b/packages/deno/src/types.ts
@@ -1,4 +1,4 @@
-import type { AIRequestInfo, MissInfo, TrailingSlashMode } from "@dualmark/core";
+import type { AIRequestInfo, MissInfo, TrailingSlashMode, TokenEstimator } from "@dualmark/core";
 
 /**
  * Minimal Deno.ServeHandlerInfo interface. Declared locally so this package
@@ -94,6 +94,9 @@ export interface CreateAEOHandlerOptions {
    * discover the markdown twin.
    */
   enableLinkHeader?: boolean;
+
+  /** Custom token estimator. Overrides the default whitespace-word counter. */
+  tokenizer?: TokenEstimator;
 }
 
-export type { AIRequestInfo, MissInfo, TrailingSlashMode };
+export type { AIRequestInfo, MissInfo, TrailingSlashMode, TokenEstimator };

--- a/packages/nextjs/src/config-validation.ts
+++ b/packages/nextjs/src/config-validation.ts
@@ -111,5 +111,6 @@ export function resolveConfig(input: DualmarkNextConfig): ResolvedDualmarkNextCo
       cacheControl: input.headers?.cacheControl ?? "public, max-age=3600",
       noindex: input.headers?.noindex !== false,
     },
+    tokenizer: input.tokenizer,
   };
 }

--- a/packages/nextjs/src/handlers/markdown-route.ts
+++ b/packages/nextjs/src/handlers/markdown-route.ts
@@ -142,6 +142,7 @@ export function createDualmarkRouteHandler(
   const responseOptions: MarkdownResponseOptions = {
     cacheControl: resolved.headers.cacheControl,
     noindex: resolved.headers.noindex,
+    tokenizer: resolved.tokenizer,
   };
 
   async function dispatch(joined: string): Promise<Response> {

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -34,3 +34,4 @@ export type {
   ParameterizedRouteConfig,
   SlugStrategy,
 } from "./types.js";
+export type { TokenEstimator } from "@dualmark/core";

--- a/packages/nextjs/src/types.ts
+++ b/packages/nextjs/src/types.ts
@@ -1,5 +1,5 @@
 import type { Converter, CollectionEntry } from "@dualmark/converters";
-import type { LlmsTxtSection } from "@dualmark/core";
+import type { LlmsTxtSection, TokenEstimator } from "@dualmark/core";
 
 export type SlugStrategy = "catch-all" | "single";
 
@@ -80,6 +80,8 @@ export interface DualmarkNextConfig {
     cacheControl?: string;
     noindex?: boolean;
   };
+  /** Custom token estimator. Overrides the default whitespace-word counter. */
+  tokenizer?: TokenEstimator;
 }
 
 export interface ResolvedDualmarkNextConfig extends DualmarkNextConfig {

--- a/packages/sveltekit/src/config-validation.ts
+++ b/packages/sveltekit/src/config-validation.ts
@@ -123,5 +123,6 @@ export function resolveConfig(input: DualmarkSvelteKitConfig): ResolvedDualmarkS
       cacheControl: input.headers?.cacheControl ?? "public, max-age=3600",
       noindex: input.headers?.noindex !== false,
     },
+    tokenizer: input.tokenizer,
   };
 }

--- a/packages/sveltekit/src/handlers.ts
+++ b/packages/sveltekit/src/handlers.ts
@@ -158,6 +158,7 @@ export function createDualmarkRouteHandler(
   const responseOptions: MarkdownResponseOptions = {
     cacheControl: resolved.headers.cacheControl,
     noindex: resolved.headers.noindex,
+    tokenizer: resolved.tokenizer,
   };
 
   async function dispatch(pagePath: string): Promise<Response> {

--- a/packages/sveltekit/src/index.ts
+++ b/packages/sveltekit/src/index.ts
@@ -31,3 +31,4 @@ export type {
   SlugStrategy,
   StaticPageConfig,
 } from "./types.js";
+export type { TokenEstimator } from "@dualmark/core";

--- a/packages/sveltekit/src/types.ts
+++ b/packages/sveltekit/src/types.ts
@@ -1,5 +1,5 @@
 import type { Converter, CollectionEntry } from "@dualmark/converters";
-import type { LlmsTxtSection } from "@dualmark/core";
+import type { LlmsTxtSection, TokenEstimator } from "@dualmark/core";
 
 export type SlugStrategy = "catch-all" | "single";
 
@@ -61,6 +61,8 @@ export interface DualmarkSvelteKitConfig {
     cacheControl?: string;
     noindex?: boolean;
   };
+  /** Custom token estimator. Overrides the default whitespace-word counter. */
+  tokenizer?: TokenEstimator;
 }
 
 export interface ResolvedDualmarkSvelteKitConfig extends DualmarkSvelteKitConfig {

--- a/packages/sveltekit/test/handlers.test.ts
+++ b/packages/sveltekit/test/handlers.test.ts
@@ -99,3 +99,29 @@ describe("createLlmsTxtHandler", () => {
     expect(response.headers.get("content-type")).toContain("text/plain");
   });
 });
+
+describe("tokenizer option", () => {
+  it("uses custom tokenizer for X-Markdown-Tokens header", async () => {
+    const charCounter = (text: string) => text.length;
+    const configWithTokenizer: DualmarkSvelteKitConfig = {
+      ...config,
+      tokenizer: charCounter,
+    };
+    const handler = createDualmarkRouteHandler(configWithTokenizer);
+    const response = await handler.GET({ url: new URL("https://example.com/index.md") });
+
+    expect(response.status).toBe(200);
+    const body = await response.clone().text();
+    const tokens = response.headers.get("x-markdown-tokens");
+    expect(Number(tokens)).toBe(body.length);
+  });
+
+  it("falls back to default word counter when no tokenizer is provided", async () => {
+    const handler = createDualmarkRouteHandler(config);
+    const response = await handler.GET({ url: new URL("https://example.com/index.md") });
+
+    expect(response.status).toBe(200);
+    const tokens = response.headers.get("x-markdown-tokens");
+    expect(Number(tokens)).toBe(2);
+  });
+});

--- a/packages/vercel/src/index.ts
+++ b/packages/vercel/src/index.ts
@@ -7,4 +7,5 @@ export type {
   AIRequestInfo,
   MissInfo,
   TrailingSlashMode,
+  TokenEstimator,
 } from "./types.js";

--- a/packages/vercel/src/middleware.ts
+++ b/packages/vercel/src/middleware.ts
@@ -60,10 +60,11 @@ function normalizePath(pathname: string): string {
 function buildMarkdownHeaders(
   body: string,
   cacheControl: string,
+  tokenizer?: (text: string) => number,
   redirectFrom?: string,
   redirectTo?: string,
 ): Headers {
-  const tokens = estimateTokens(body);
+  const tokens = estimateTokens(body, { tokenizer });
   const headers = new Headers({
     "Content-Type": "text/markdown; charset=utf-8",
     "X-Content-Type-Options": "nosniff",
@@ -108,6 +109,7 @@ export function createAEOMiddleware(
   const trailingSlash = options.trailingSlash ?? "never";
   const cacheControl = options.headers?.cacheControl ?? DEFAULT_CACHE_CONTROL;
   const enableLinkHeader = options.enableLinkHeader !== false;
+  const tokenizer = options.tokenizer;
 
   const onAIRequest = options.hooks?.onAIRequest;
   const onMiss = options.hooks?.onMiss;
@@ -163,7 +165,7 @@ export function createAEOMiddleware(
         const body = await assetResponse.text();
         return new Response(body, {
           status: 200,
-          headers: buildMarkdownHeaders(body, cacheControl),
+          headers: buildMarkdownHeaders(body, cacheControl, tokenizer),
         });
       }
       return assetResponse ?? new Response("Not Found", { status: 404 });
@@ -199,7 +201,7 @@ export function createAEOMiddleware(
 
         if (assetResponse && assetResponse.ok) {
           const body = await assetResponse.text();
-          const tokens = estimateTokens(body);
+          const tokens = estimateTokens(body, { tokenizer });
           const info: AIRequestInfo = {
             url,
             botName: bot.name,
@@ -213,7 +215,7 @@ export function createAEOMiddleware(
           else if (onAIRequest) onAIRequest(info);
           return new Response(body, {
             status: 200,
-            headers: buildMarkdownHeaders(body, cacheControl),
+            headers: buildMarkdownHeaders(body, cacheControl, tokenizer),
           });
         }
 
@@ -228,7 +230,7 @@ export function createAEOMiddleware(
             );
             if (targetResp.ok) {
               const body = await targetResp.text();
-              const tokens = estimateTokens(body);
+              const tokens = estimateTokens(body, { tokenizer });
               const info: AIRequestInfo = {
                 url,
                 botName: bot.name,
@@ -242,7 +244,7 @@ export function createAEOMiddleware(
               else if (onAIRequest) onAIRequest(info);
               return new Response(body, {
                 status: 200,
-                headers: buildMarkdownHeaders(body, cacheControl, cleanPath, internalTarget),
+                headers: buildMarkdownHeaders(body, cacheControl, tokenizer, cleanPath, internalTarget),
               });
             }
           } catch {
@@ -253,7 +255,7 @@ export function createAEOMiddleware(
         const externalTarget = externalRedirects[cleanPath];
         if (externalTarget) {
           const body = `# Redirect\n\nThis page has moved to an external location.\n\n- **Redirect**: [${externalTarget}](${externalTarget})\n`;
-          const tokens = estimateTokens(body);
+          const tokens = estimateTokens(body, { tokenizer });
           const info: AIRequestInfo = {
             url,
             botName: bot.name,
@@ -267,7 +269,7 @@ export function createAEOMiddleware(
           else if (onAIRequest) onAIRequest(info);
           return new Response(body, {
             status: 200,
-            headers: buildMarkdownHeaders(body, cacheControl, cleanPath, externalTarget),
+            headers: buildMarkdownHeaders(body, cacheControl, tokenizer, cleanPath, externalTarget),
           });
         }
 

--- a/packages/vercel/src/types.ts
+++ b/packages/vercel/src/types.ts
@@ -1,6 +1,6 @@
-import type { AIRequestInfo, MissInfo, TrailingSlashMode } from "@dualmark/core";
+import type { AIRequestInfo, MissInfo, TrailingSlashMode, TokenEstimator } from "@dualmark/core";
 
-export type { AIRequestInfo, MissInfo, TrailingSlashMode };
+export type { AIRequestInfo, MissInfo, TrailingSlashMode, TokenEstimator };
 
 export interface VercelEdgeContext {
   waitUntil: (promise: Promise<unknown>) => void;
@@ -30,4 +30,6 @@ export interface CreateAEOMiddlewareOptions {
     onMiss?: (info: MissInfo) => void | Promise<void>;
   };
   enableLinkHeader?: boolean;
+  /** Custom token estimator. Overrides the default whitespace-word counter. */
+  tokenizer?: TokenEstimator;
 }


### PR DESCRIPTION
## Summary

This PR adds optional `tokenizer` param to `estimateTokens()` and plumb it through all adapters so users can swap in a real tokenizer (e.g. `js-tiktoken`) without changing default behavior.

Closes #21

## Changes

- `estimateTokens(text, { tokenizer })`  inline override, falls back to global/default
- Export `TokenEstimator` type + `setTokenEstimator`/`resetTokenEstimator` from core barrel
- Add `tokenizer` option to `MarkdownResponseOptions`, `CreateAEOWorkerOptions`, `CreateAEOHandlerOptions`, `DualmarkAstroConfig`, `DualmarkNextConfig`
- Tests for both paths

## Type

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change
- [ ] Spec change (requires bump in `AEO_SPEC_VERSION`)
- [ ] Docs / examples / tooling only

## Verification

- [x] `bun run build` passes
- [x] `bun run test` passes
- [x] `bun run typecheck` passes
- [ ] If touching examples: ran `dualmark verify` against the example end-to-end
- [ ] If touching `/spec/`: ran `bun run --filter dualmark-docs sync-spec` and committed the mirror

## Changeset

- [ ] Added a changeset (`bun run changeset`) for any package with a user-visible change
