### PR TITLE
feat: shareable score links and og card images

### DIFF
--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -11,6 +11,12 @@ bun run build
 bun run start
 ```
 
+## Environment
+
+`DUALMARK_SHARE_SECRET` signs the share tokens used by `/play` score links and
+the `/api/og/score` card. Set it to any long random string. Without it the
+playground still works; the share buttons just don't show up.
+
 ## Structure
 
 ```

--- a/apps/docs/app/api/og/score/route.tsx
+++ b/apps/docs/app/api/og/score/route.tsx
@@ -1,0 +1,26 @@
+import { renderScoreOgImage } from "@/lib/og";
+import { verifySharePayload } from "@/lib/share-token";
+
+export const runtime = "edge";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const token = searchParams.get("token");
+
+  const payload = token ? await verifySharePayload(token) : null;
+  if (!payload) {
+    return new Response("Invalid or missing token", { status: 404 });
+  }
+
+  const response = renderScoreOgImage({
+    url: payload.u,
+    score: payload.s,
+    maxScore: payload.m,
+  });
+  response.headers.set(
+    "cache-control",
+    "public, max-age=31536000, s-maxage=31536000, immutable",
+  );
+  return response;
+}

--- a/apps/docs/app/api/play/score/route.ts
+++ b/apps/docs/app/api/play/score/route.ts
@@ -1,5 +1,6 @@
 import { type VerifyReport, verifyUrl } from "@dualmark/cli";
 import { NextResponse } from "next/server";
+import { signSharePayload } from "@/lib/share-token";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -191,6 +192,23 @@ function summarize(
   };
 }
 
+// Signing needs DUALMARK_SHARE_SECRET. If it's unset (e.g. local dev), skip the
+// token so scoring still works; the client just won't show a share link.
+async function buildShareToken(
+  report: VerifyReport,
+): Promise<string | undefined> {
+  try {
+    return await signSharePayload({
+      u: report.url,
+      s: report.score,
+      m: report.maxScore,
+      t: Math.floor(Date.now() / 1000),
+    });
+  } catch {
+    return undefined;
+  }
+}
+
 export async function POST(request: Request) {
   let body: unknown;
   try {
@@ -231,8 +249,12 @@ export async function POST(request: Request) {
       }),
       detectFramework(parsed.toString()),
     ]);
+    const shareToken = await buildShareToken(report);
     return NextResponse.json(
-      summarize(report, detection.framework, detection.signals),
+      {
+        ...summarize(report, detection.framework, detection.signals),
+        shareToken,
+      },
       { headers: { "cache-control": "no-store" } },
     );
   } catch (err) {

--- a/apps/docs/app/play/playground-client.tsx
+++ b/apps/docs/app/play/playground-client.tsx
@@ -37,6 +37,7 @@ interface ScoreResult {
   skippedNegotiation: boolean;
   passed: CheckSummary[];
   failed: CheckSummary[];
+  shareToken?: string;
 }
 
 const FRAMEWORK_LABEL: Record<Framework, string> = {
@@ -411,6 +412,8 @@ function ResultPanel({ result }: { result: ScoreResult }) {
         </div>
       </section>
 
+      <ShareBar result={result} />
+
       <CheckList
         title="Failed — required"
         accent="var(--color-danger)"
@@ -435,6 +438,90 @@ function ResultPanel({ result }: { result: ScoreResult }) {
 
       <NextStepsCard result={result} />
     </div>
+  );
+}
+
+function hostFromUrl(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}
+
+function ShareBar({ result }: { result: ScoreResult }) {
+  const [copied, setCopied] = useState(false);
+  const token = result.shareToken;
+
+  useEffect(() => {
+    if (!copied) return;
+    const t = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(t);
+  }, [copied]);
+
+  if (!token) return null;
+
+  const host = hostFromUrl(result.url);
+  const shareUrl = () => `${window.location.origin}/play/r/${token}`;
+  const imageUrl = `/api/og/score?token=${encodeURIComponent(token)}`;
+
+  async function copyLink() {
+    try {
+      await navigator.clipboard.writeText(shareUrl());
+      setCopied(true);
+    } catch {
+      void 0;
+    }
+  }
+
+  function postToX() {
+    const text = `${host} scored ${result.score}/${result.maxScore} (${result.level}) on the AEO Spec v1.0`;
+    const intent = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+      text,
+    )}&url=${encodeURIComponent(shareUrl())}`;
+    window.open(intent, "_blank", "noopener,noreferrer");
+  }
+
+  return (
+    <section className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-elev-1)]/40 px-5 py-4">
+      <div className="flex items-center gap-2">
+        <ShareIcon className="size-4 text-[var(--color-accent)]" />
+        <span className="font-mono text-[11px] uppercase tracking-[0.16em] text-[var(--color-fg-subtle)]">
+          Share this score
+        </span>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={copyLink}
+          className="inline-flex h-9 items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elev-1)] px-3 text-xs font-medium text-[var(--color-fg)] transition-colors hover:border-[var(--color-accent)]/50 hover:bg-[var(--color-bg-elev-2)]"
+        >
+          {copied ? (
+            <CheckIcon className="size-4 text-[var(--color-success)]" />
+          ) : (
+            <UrlIcon className="size-4" />
+          )}
+          {copied ? "Copied!" : "Copy link"}
+        </button>
+        <button
+          type="button"
+          onClick={postToX}
+          className="inline-flex h-9 items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elev-1)] px-3 text-xs font-medium text-[var(--color-fg)] transition-colors hover:border-[var(--color-accent)]/50 hover:bg-[var(--color-bg-elev-2)]"
+        >
+          <XGlyph className="size-3.5" />
+          Post on X
+        </button>
+        <a
+          href={imageUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex h-9 items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elev-1)] px-3 text-xs font-medium text-[var(--color-fg)] transition-colors hover:border-[var(--color-accent)]/50 hover:bg-[var(--color-bg-elev-2)]"
+        >
+          <ImageIcon className="size-4" />
+          Image
+        </a>
+      </div>
+    </section>
   );
 }
 
@@ -991,6 +1078,51 @@ function CursorGlyph({ className }: { className?: string }) {
         d="M22.35 5.99L11.925 12 1.5 5.99 11.925 24V12z"
         fill="currentColor"
         opacity="0.55"
+      />
+    </svg>
+  );
+}
+function ShareIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden>
+      <path
+        d="M8.7 13.3 15.3 17M15.3 7 8.7 10.7M18 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM6 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Zm12 7a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+function XGlyph({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} aria-hidden>
+      <path
+        d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24h-6.66l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231 5.45-6.231Zm-1.161 17.52h1.833L7.084 4.126H5.117L17.083 19.77Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+function ImageIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden>
+      <rect
+        x="3"
+        y="4"
+        width="18"
+        height="16"
+        rx="2"
+        stroke="currentColor"
+        strokeWidth="1.6"
+      />
+      <circle cx="8.5" cy="9.5" r="1.5" fill="currentColor" />
+      <path
+        d="m4 18 5-5 4 4 3-3 4 4"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
     </svg>
   );

--- a/apps/docs/app/play/r/[token]/page.tsx
+++ b/apps/docs/app/play/r/[token]/page.tsx
@@ -1,0 +1,143 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { BrandMark } from "../../../_components/brand-mark";
+import {
+  levelFromScore,
+  type ScoreLevel,
+  type SharePayload,
+  verifySharePayload,
+} from "@/lib/share-token";
+
+interface PageProps {
+  params: Promise<{ token: string }>;
+}
+
+const LEVEL_TONE: Record<ScoreLevel, { color: string; border: string }> = {
+  Advanced: {
+    color: "var(--color-success)",
+    border: "rgba(74, 222, 128, 0.4)",
+  },
+  Standard: {
+    color: "var(--color-accent-strong)",
+    border: "rgba(198, 254, 30, 0.45)",
+  },
+  Basic: { color: "var(--color-warning)", border: "rgba(251, 191, 36, 0.4)" },
+  "Below Basic": {
+    color: "var(--color-danger)",
+    border: "rgba(248, 113, 113, 0.4)",
+  },
+};
+
+function hostOf(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { token } = await params;
+  const payload = await verifySharePayload(token);
+  if (!payload) {
+    return { title: "Score not found" };
+  }
+
+  const host = hostOf(payload.u);
+  const level = levelFromScore(payload.s, payload.m);
+  const title = `${host} scored ${payload.s}/${payload.m} — ${level}`;
+  const description = `AEO Spec v1.0 conformance for ${host}. Score your own site at dualmark.dev/play.`;
+  const image = `/api/og/score?token=${encodeURIComponent(token)}`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url: `/play/r/${token}`,
+      type: "website",
+      images: [{ url: image, width: 1200, height: 630 }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [image],
+    },
+  };
+}
+
+export default async function SharedScorePage({ params }: PageProps) {
+  const { token } = await params;
+  const payload = await verifySharePayload(token);
+  if (!payload) {
+    notFound();
+  }
+
+  return <SharedScore payload={payload as SharePayload} />;
+}
+
+function SharedScore({ payload }: { payload: SharePayload }) {
+  const host = hostOf(payload.u);
+  const level = levelFromScore(payload.s, payload.m);
+  const tone = LEVEL_TONE[level];
+  const percentage =
+    payload.m > 0 ? Math.round((payload.s / payload.m) * 100) : 0;
+  const rescanHref = `/play?url=${encodeURIComponent(payload.u)}`;
+
+  return (
+    <main className="mx-auto flex min-h-[calc(100vh-3.5rem)] max-w-2xl flex-col items-center justify-center gap-8 px-5 py-16">
+      <Link href="/play" className="flex items-center gap-2">
+        <BrandMark size={22} />
+        <span className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--color-fg-subtle)]">
+          AEO Spec v1.0
+        </span>
+      </Link>
+
+      <section
+        className="flex w-full flex-col items-center gap-5 rounded-2xl border bg-[var(--color-bg-elev-1)] px-8 py-10 text-center shadow-2xl shadow-black/30"
+        style={{ borderColor: tone.border }}
+      >
+        <div className="font-mono text-sm text-[var(--color-fg-muted)]">
+          {host}
+        </div>
+        <div className="flex items-end gap-1">
+          <span
+            className="font-mono text-6xl font-semibold tracking-tight"
+            style={{ color: tone.color }}
+          >
+            {payload.s}
+          </span>
+          <span className="mb-2 font-mono text-xl text-[var(--color-fg-subtle)]">
+            / {payload.m}
+          </span>
+        </div>
+        <span
+          className="inline-flex items-center rounded-full border px-4 py-1.5 font-mono text-xs uppercase tracking-[0.18em]"
+          style={{ color: tone.color, borderColor: tone.border }}
+        >
+          {level} · {percentage}%
+        </span>
+      </section>
+
+      <div className="flex flex-wrap items-center justify-center gap-3">
+        <Link
+          href={rescanHref}
+          className="inline-flex items-center gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elev-1)] px-4 py-2 text-sm font-medium text-[var(--color-fg)] transition-colors hover:border-[var(--color-border-strong)]"
+        >
+          Re-scan this site
+        </Link>
+        <Link
+          href="/play"
+          className="inline-flex items-center gap-2 rounded-md bg-[var(--color-fg)] px-4 py-2 text-sm font-medium text-[var(--color-bg)] transition-opacity hover:opacity-90"
+        >
+          Score your site →
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/docs/lib/og.tsx
+++ b/apps/docs/lib/og.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from "next/og";
+import { levelFromScore, type ScoreLevel } from "./share-token";
 
 export const OG_SIZE = { width: 1200, height: 630 };
 export const OG_CONTENT_TYPE = "image/png";
@@ -101,6 +102,208 @@ export function renderOgImage({ title, description, eyebrow, footer }: OgConfig)
       >
         <span>{footer ?? "$ bun add @dualmark/astro"}</span>
         <span>dualmark.dev</span>
+      </div>
+    </div>,
+    { ...OG_SIZE },
+  );
+}
+
+const LEVEL_COLOR: Record<ScoreLevel, string> = {
+  Advanced: "#4ade80",
+  Standard: "#C6FE1E",
+  Basic: "#fbbf24",
+  "Below Basic": "#f87171",
+};
+
+function hostFromUrl(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}
+
+interface ScoreOgConfig {
+  url: string;
+  score: number;
+  maxScore: number;
+}
+
+export function renderScoreOgImage({ url, score, maxScore }: ScoreOgConfig) {
+  const level = levelFromScore(score, maxScore);
+  const color = LEVEL_COLOR[level];
+  const ratio = maxScore > 0 ? score / maxScore : 0;
+  const percentage = Math.round(ratio * 100);
+  const host = hostFromUrl(url);
+
+  const r = 90;
+  const circumference = 2 * Math.PI * r;
+  const offset = circumference * (1 - ratio);
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        background: "#0a0a0a",
+        backgroundImage:
+          "radial-gradient(circle at 25% 30%, rgba(198,254,30,0.18), transparent 55%), radial-gradient(circle at 75% 75%, rgba(158,232,71,0.10), transparent 55%)",
+        padding: "72px 80px",
+        fontFamily: "system-ui, sans-serif",
+        color: "#fafafa",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "14px" }}>
+        <svg width="48" height="48" viewBox="0 0 43 42" fill="none">
+          <path
+            d="M21.0101 -0.00671387C9.40515 -0.00671387 -0.00317383 9.39863 -0.00317383 20.9998C-0.00317383 32.6011 9.40515 42.0064 21.0101 42.0064C32.615 42.0064 42.0233 32.6011 42.0233 20.9998C42.0233 9.39863 32.615 -0.00671387 21.0101 -0.00671387Z"
+            fill="#C6FE1E"
+          />
+          <path
+            d="M18.5025 15.5044H18.4885C17.62 15.2551 16.701 15.7537 16.4068 16.5771C16.0818 17.4622 16.5973 18.4761 17.5079 18.7562C19.7381 19.3892 20.6963 16.1934 18.5025 15.5044Z"
+            fill="#0D0D0D"
+          />
+          <path
+            d="M37.5098 20.0222C34.6379 13.7342 25.4762 16.3362 24.63 14.6893C22.1505 10.7989 17.522 8.61421 12.518 9.74016C11.7475 9.43207 9.09427 9.34804 7.37959 10.4264L8.41344 10.8829C8.49189 10.9165 8.46948 10.9081 8.58435 10.9501C9.05224 11.1266 8.97099 11.0762 8.63478 11.261C7.86429 11.712 6.90329 12.2357 6.30371 13.0228C6.32893 13.0592 7.62334 13.3701 7.62334 13.3701C7.64576 13.3757 7.88671 13.4009 7.83347 13.5073C3.60001 20.1902 10.7389 30.2762 14.2047 35.7043H24.2378C22.6884 32.9314 20.9177 29.1474 21.5229 26.579C21.6322 26.1141 21.7722 25.5231 22.3438 25.4447C23.7251 25.2234 25.5742 25.243 26.8911 25.0946C26.8911 25.0946 26.8976 25.0946 26.9107 25.0946C27.1909 25.0806 34.0496 24.2095 35.6914 28.4836C35.8315 28.8757 36.1537 28.6209 36.2826 28.3632C37.507 25.9292 38.2971 22.0976 37.5154 20.025L37.5098 20.0222ZM26.4372 17.9579C25.9553 18.8178 25.6275 19.9353 25.5434 20.9101C25.4986 21.529 25.563 22.1396 25.6247 22.7586C25.6583 23.1003 25.6611 23.5317 25.3865 23.7557C25.1484 23.9574 24.7533 23.977 24.3555 24.005C22.4026 23.9966 17.6396 24.005 15.8045 22.7558L15.7933 22.7474C13.1232 21.1201 11.6943 17.4454 13.2801 14.5913C13.7928 13.6222 14.737 12.992 15.8129 12.7539C17.197 12.4374 18.7211 12.6727 19.9567 13.3197C20.461 13.5746 21.0634 13.9107 21.5229 14.2972C22.4335 15.0926 23.2124 15.9189 24.4059 16.1738C24.9551 16.3306 25.5266 16.3082 26.0758 16.4202C27.104 16.6667 26.8462 17.2521 26.4344 17.9523L26.4372 17.9579Z"
+            fill="#0D0D0D"
+          />
+        </svg>
+        <span style={{ fontSize: 14, color: "#52525b", margin: "0 2px" }}>
+          /
+        </span>
+        <span
+          style={{ fontSize: 34, fontWeight: 700, letterSpacing: "-0.02em" }}
+        >
+          Dualmark
+        </span>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: "48px",
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: "20px" }}>
+          <div
+            style={{
+              fontSize: 18,
+              fontFamily: "monospace",
+              color: "#C6FE1E",
+              textTransform: "uppercase",
+              letterSpacing: "0.18em",
+            }}
+          >
+            AEO Spec v1.0
+          </div>
+          <div
+            style={{
+              fontSize: 64,
+              fontWeight: 700,
+              lineHeight: 1.05,
+              letterSpacing: "-0.04em",
+              maxWidth: 640,
+            }}
+          >
+            {host}
+          </div>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              alignSelf: "flex-start",
+              borderRadius: 999,
+              border: `2px solid ${color}`,
+              color,
+              padding: "10px 22px",
+              fontSize: 26,
+              fontWeight: 600,
+            }}
+          >
+            {level} · {percentage}%
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            position: "relative",
+            width: 220,
+            height: 220,
+          }}
+        >
+          <svg
+            width="220"
+            height="220"
+            viewBox="0 0 220 220"
+            style={{ transform: "rotate(-90deg)" }}
+          >
+            <circle
+              cx="110"
+              cy="110"
+              r={r}
+              fill="none"
+              stroke="#27272a"
+              strokeWidth="16"
+            />
+            <circle
+              cx="110"
+              cy="110"
+              r={r}
+              fill="none"
+              stroke={color}
+              strokeWidth="16"
+              strokeLinecap="round"
+              strokeDasharray={circumference}
+              strokeDashoffset={offset}
+            />
+          </svg>
+          <div
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              width: 220,
+              height: 220,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <span style={{ fontSize: 72, fontWeight: 700, color }}>
+              {score}
+            </span>
+            <span
+              style={{
+                fontSize: 26,
+                color: "#71717a",
+                fontFamily: "monospace",
+              }}
+            >
+              / {maxScore}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          fontSize: 20,
+          color: "#71717a",
+          fontFamily: "monospace",
+        }}
+      >
+        <span>$ dualmark verify {host}</span>
+        <span>dualmark.dev/play</span>
       </div>
     </div>,
     { ...OG_SIZE },

--- a/apps/docs/lib/share-token.ts
+++ b/apps/docs/lib/share-token.ts
@@ -1,0 +1,129 @@
+// Share tokens carry a signed score result inside the URL so the OG card and
+// result page can render without re-running the 12s verification. Format is
+// `payload.signature`, payload is base64url JSON, signature is HMAC-SHA256.
+//
+// Web Crypto (not node:crypto) because the score route signs on the Node
+// runtime but the OG route verifies on Edge, and only crypto.subtle is in both.
+
+// The docs tsconfig doesn't include @types/node, so declare the one global we read.
+declare const process: { env: Record<string, string | undefined> };
+
+export type ScoreLevel = "Advanced" | "Standard" | "Basic" | "Below Basic";
+
+export interface SharePayload {
+  u: string;
+  s: number;
+  m: number;
+  t: number;
+}
+
+function getSecret(): string {
+  const secret = process.env.DUALMARK_SHARE_SECRET;
+  if (!secret) {
+    throw new Error("DUALMARK_SHARE_SECRET is not set");
+  }
+  return secret;
+}
+
+function b64urlEncode(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) {
+    bin += String.fromCharCode(b);
+  }
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function b64urlDecode(str: string): Uint8Array {
+  const pad = str.length % 4 === 0 ? "" : "=".repeat(4 - (str.length % 4));
+  const bin = atob(str.replace(/-/g, "+").replace(/_/g, "/") + pad);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) {
+    bytes[i] = bin.charCodeAt(i);
+  }
+  return bytes;
+}
+
+async function hmac(message: string): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(getSecret()),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(message),
+  );
+  return new Uint8Array(sig);
+}
+
+function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= (a[i] ?? 0) ^ (b[i] ?? 0);
+  }
+  return diff === 0;
+}
+
+function isSharePayload(value: unknown): value is SharePayload {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "u" in value &&
+    typeof value.u === "string" &&
+    "s" in value &&
+    typeof value.s === "number" &&
+    "m" in value &&
+    typeof value.m === "number" &&
+    "t" in value &&
+    typeof value.t === "number"
+  );
+}
+
+export async function signSharePayload(payload: SharePayload): Promise<string> {
+  const body = b64urlEncode(new TextEncoder().encode(JSON.stringify(payload)));
+  const sig = b64urlEncode(await hmac(body));
+  return `${body}.${sig}`;
+}
+
+export async function verifySharePayload(
+  token: string,
+): Promise<SharePayload | null> {
+  const dot = token.indexOf(".");
+  if (dot <= 0 || dot === token.length - 1) {
+    return null;
+  }
+
+  const body = token.slice(0, dot);
+  const sig = token.slice(dot + 1);
+
+  try {
+    const expected = await hmac(body);
+    if (!equalBytes(expected, b64urlDecode(sig))) {
+      return null;
+    }
+    const parsed = JSON.parse(new TextDecoder().decode(b64urlDecode(body)));
+    return isSharePayload(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function levelFromScore(score: number, maxScore: number): ScoreLevel {
+  const ratio = maxScore > 0 ? score / maxScore : 0;
+  if (ratio >= 0.95) {
+    return "Advanced";
+  }
+  if (ratio >= 0.8) {
+    return "Standard";
+  }
+  if (ratio >= 0.6) {
+    return "Basic";
+  }
+  return "Below Basic";
+}


### PR DESCRIPTION
## Summary

Adds a share flow to the playground. when you score a site you now get a signed link (/play/r/) and an og image at `/api/og/score`, so dropping the link on x or slack unfurls a card with the score, level and domain. the result rides inside the url as an hmac signed token, no datastore, and the signature stops anyone faking a score. one env var, `DUALMARK_SHARE_SECRET`, signs the tokens. if its unset the playground still works, the share buttons just dont render.

Note: we need to move the snapshots into a kv cache store (vercel kv / upstash) instead of url tokens. that gives short opaque links, real expiry and revocation, and room to store the full check breakdown. currently we pack the whole result into the url as an hmac signed token, so theres no datastore to run, but the links are long and you cant expire or revoke a single one.

<img width="1200" height="630" alt="image" src="https://github.com/user-attachments/assets/a6d58874-abd2-4606-9485-b4388f074404" />

<img width="1512" height="860" alt="image" src="https://github.com/user-attachments/assets/263c2413-c4a2-4f68-87e4-277bb264ff17" />


## Changes

Fixes #42 

## Type

- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Breaking change
- [ ] Spec change (requires bump in `AEO_SPEC_VERSION`)
- [ ] Docs / examples / tooling only

## Verification

- [x] `bun run build` passes
- [x] `bun run test` passes
- [x] `bun run typecheck` passes
- [ ] If touching examples: ran `dualmark verify` against the example end-to-end
- [ ] If touching `/spec/`: ran `bun run --filter dualmark-docs sync-spec` and committed the mirror

## Changeset

- [ ] Added a changeset (`bun run changeset`) for any package with a user-visible change
