### PR TITLE
Fix docs search returning empty results

### DIFF
--- a/apps/docs/app/api/search/route.ts
+++ b/apps/docs/app/api/search/route.ts
@@ -1,7 +1,4 @@
 import { createFromSource } from "fumadocs-core/search/server";
 import { source } from "@/lib/source";
 
-export const dynamic = "force-static";
-export const revalidate = false;
-
 export const { GET } = createFromSource(source);


### PR DESCRIPTION
## Summary

Fixes #59 by enabling the docs search endpoint to handle runtime search queries correctly.

## Changes

* Removed `force-static` configuration from `apps/docs/app/api/search/route.ts`
* Allowed the search endpoint to process incoming query parameters dynamically
* Fixed docs search returning empty results for valid queries such as `core`, `cli`, and `quickstart`

## Type

* [x] Bug fix (non-breaking)
* [ ] New feature (non-breaking)
* [ ] Breaking change
* [ ] Spec change (requires bump in `AEO_SPEC_VERSION`)
* [ ] Docs / examples / tooling only

## Verification

* [ ] `bun run build` passes
* [ ] `bun run test` passes
* [ ] `bun run typecheck` passes
* [ ] If touching examples: ran `dualmark verify` against the example end-to-end
* [ ] If touching `/spec/`: ran `bun run --filter dualmark-docs sync-spec` and committed the mirror

### Manual verification

* [x] Verified `/api/search?query=core` returns results instead of `[]`
* [x] Verified `/api/search?query=quickstart` returns results instead of `[]`
* [x] Verified docs search UI returns matching results

## Screenshots

### Before

*Search for `cli` returned no results.*

<img width="1918" height="953" alt="Screenshot 2026-06-08 003832" src="https://github.com/user-attachments/assets/1b0be49b-0e7b-4e2d-a78c-2ef7a09d22dd" />


### After

*Search for `cli` returns matching documentation results.*

<img width="1918" height="966" alt="Screenshot 2026-06-08 003703" src="https://github.com/user-attachments/assets/7d2e6f5c-06bc-422b-8005-d05fbac25b20" />


## Changeset

* [ ] Added a changeset (`bun run changeset`) for any package with a user-visible change
