### PR TITLE
feat(converters): add OpenAPI-aware api-reference converter

### DIFF
--- a/.changeset/api-reference-converter.md
+++ b/.changeset/api-reference-converter.md
@@ -1,0 +1,7 @@
+---
+"@dualmark/converters": minor
+"@dualmark/astro": minor
+"@dualmark/nextjs": minor
+---
+
+Add new OpenAPI-aware `api-reference` converter with `fromOpenAPI` helper.

--- a/.changeset/api-reference-converter.md
+++ b/.changeset/api-reference-converter.md
@@ -2,6 +2,7 @@
 "@dualmark/converters": minor
 "@dualmark/astro": minor
 "@dualmark/nextjs": minor
+"@dualmark/sveltekit": minor
 ---
 
 Add new OpenAPI-aware `api-reference` converter with `fromOpenAPI` helper.

--- a/apps/docs/app/_components/adapters.tsx
+++ b/apps/docs/app/_components/adapters.tsx
@@ -11,6 +11,7 @@ import type { ComponentType, SVGProps } from "react";
 import { Section, SectionHeader } from "./section";
 
 const CONVERTERS = [
+  "api-reference",
   "blog",
   "case-study",
   "changelog",
@@ -166,7 +167,7 @@ export function Adapters() {
 
       <div className="mt-10 flex flex-col items-center gap-3 text-center">
         <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-[var(--color-fg-subtle)]">
-          + 14 page-type converters
+          + 15 page-type converters
         </span>
         <div className="flex flex-wrap items-center justify-center gap-1.5">
           {CONVERTERS.map((name) => (

--- a/apps/docs/content/docs/packages/converters.mdx
+++ b/apps/docs/content/docs/packages/converters.mdx
@@ -27,6 +27,7 @@ Each factory takes a config object and returns `(entry: CollectionEntry<Data>) =
 
 | Factory | Domain |
 | --- | --- |
+| `apiReferenceConverter` | API References (with `fromOpenAPI` helper) |
 | `blogConverter` | Blog posts |
 | `caseStudyConverter` | Case studies (with stats + customer quote) |
 | `changelogConverter` | Release notes (Keep-a-Changelog grouping) |
@@ -65,6 +66,19 @@ const md = convert({
   },
   body: "Long-form content.",
 });
+```
+
+### OpenAPI helper
+
+Note that OpenAPI YAML must be parsed into a JavaScript object before calling `fromOpenAPI()`.
+
+```ts
+import { fromOpenAPI, apiReferenceConverter } from "@dualmark/converters";
+import { parse } from "yaml";
+
+const spec = parse(yamlString); // You must provide a parsed JS object
+const entry = fromOpenAPI(spec, "getPetById");
+const md = apiReferenceConverter({ siteUrl: "https://example.com" })(entry);
 ```
 
 ## All factories accept

--- a/packages/astro/src/converter-registry.ts
+++ b/packages/astro/src/converter-registry.ts
@@ -1,4 +1,5 @@
 import {
+  apiReferenceConverter,
   blogConverter,
   caseStudyConverter,
   changelogConverter,
@@ -19,6 +20,7 @@ import {
 } from "@dualmark/converters";
 
 export type BuiltInConverterName =
+  | "api-reference"
   | "blog"
   | "case-study"
   | "changelog"
@@ -46,6 +48,8 @@ export function resolveBuiltInConverter(
   const basePath = `/${args.collectionName}`;
   const cfg = { ...args.baseConfig, basePath };
   switch (args.name as BuiltInConverterName) {
+    case "api-reference":
+      return apiReferenceConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "blog":
       return blogConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "case-study":
@@ -78,7 +82,7 @@ export function resolveBuiltInConverter(
       return videoConverter(cfg) as Converter<CollectionEntry<unknown>>;
     default:
       throw new Error(
-        `Dualmark: unknown built-in converter '${args.name}'. Valid names: blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, status-page, tool, video. Or pass a function.`,
+        `Dualmark: unknown built-in converter '${args.name}'. Valid names: api-reference, blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, status-page, tool, video. Or pass a function.`,
       );
   }
 }

--- a/packages/astro/test/integration.test.ts
+++ b/packages/astro/test/integration.test.ts
@@ -198,6 +198,26 @@ describe("converter-registry resolveBuiltInConverter", () => {
     expect(out).toContain("# X");
   });
 
+  it("returns a callable converter for 'api-reference'", async () => {
+    const { resolveBuiltInConverter } = await import("../src/converter-registry.js");
+    const conv = resolveBuiltInConverter({
+      name: "api-reference",
+      collectionName: "api",
+      baseConfig: { siteUrl: "https://example.com" },
+    });
+    const out = conv({
+      id: "get-users",
+      data: {
+        title: "Get Users",
+        method: "get",
+        path: "/users",
+      },
+    } as never);
+    expect(out).toContain("# Get Users");
+    expect(out).toContain("- **Method**: GET");
+    expect(out).toContain("- **Path**: `/users`");
+  });
+
   it("returns a callable converter for 'status-page'", async () => {
     const { resolveBuiltInConverter } = await import("../src/converter-registry.js");
     const conv = resolveBuiltInConverter({

--- a/packages/converters/README.md
+++ b/packages/converters/README.md
@@ -12,6 +12,7 @@ bun add @dualmark/converters @dualmark/core
 
 | Factory | Domain |
 |---|---|
+| `apiReferenceConverter` | API References (with `fromOpenAPI` helper) |
 | `blogConverter` | Blog posts |
 | `caseStudyConverter` | Case studies (with stats + customer quote) |
 | `changelogConverter` | Release notes (Keep-a-Changelog grouping) |
@@ -46,6 +47,19 @@ const md = convert({
 ```
 
 Each factory takes a config object and returns a `(entry) => string` converter. Pass them to `@dualmark/astro` collection config or call directly from your own framework.
+
+### OpenAPI helper
+
+Note that OpenAPI YAML must be parsed into a JavaScript object before calling `fromOpenAPI()`.
+
+```ts
+import { fromOpenAPI, apiReferenceConverter } from "@dualmark/converters";
+import { parse } from "yaml";
+
+const spec = parse(yamlString); // You must provide a parsed JS object
+const entry = fromOpenAPI(spec, "getPetById");
+const md = apiReferenceConverter({ siteUrl: "https://example.com" })(entry);
+```
 
 ## License
 

--- a/packages/converters/src/api-reference.ts
+++ b/packages/converters/src/api-reference.ts
@@ -96,7 +96,7 @@ export function apiReferenceConverter(
         const typeStr = formatSchemaType(p.schema);
         const reqStr = p.required ? "Yes" : "No";
         const desc = p.description ? p.description.replace(/\n/g, " ") : "";
-        parts.push(`| \`${p.name}\` | ${p.in} | ${typeStr} | ${reqStr} | ${desc} |`);
+        parts.push(`| \`${escapeCell(p.name)}\` | ${escapeCell(p.in)} | ${escapeCell(typeStr)} | ${reqStr} | ${escapeCell(desc)} |`);
       }
     }
 
@@ -129,6 +129,10 @@ export function apiReferenceConverter(
     );
     return normalizeUnicode(md);
   };
+}
+
+function escapeCell(val?: string): string {
+  return val ? String(val).replace(/\|/g, "\\|") : "";
 }
 
 function formatSchemaType(schema?: OpenAPISchema): string {
@@ -197,7 +201,7 @@ function formatRequestBody(reqBody: OpenAPIRequestBody): string {
           out += "| --- | --- | --- | --- |\n";
           for (const f of fields) {
             const reqStr = f.required ? "Yes" : "No";
-            out += `| \`${f.name}\` | ${f.type} | ${reqStr} | ${f.description} |\n`;
+            out += `| \`${escapeCell(f.name)}\` | ${escapeCell(f.type)} | ${reqStr} | ${escapeCell(f.description)} |\n`;
           }
           out += "\n";
         }
@@ -224,7 +228,7 @@ function formatResponses(responses: Record<string, OpenAPIResponse>): string {
             out += "| --- | --- | --- | --- |\n";
             for (const f of fields) {
               const reqStr = f.required ? "Yes" : "No";
-              out += `| \`${f.name}\` | ${f.type} | ${reqStr} | ${f.description} |\n`;
+              out += `| \`${escapeCell(f.name)}\` | ${escapeCell(f.type)} | ${reqStr} | ${escapeCell(f.description)} |\n`;
             }
             out += "\n";
           }
@@ -313,7 +317,7 @@ export function fromOpenAPI(spec: any, operationId: string): CollectionEntry<Api
     id: operationId,
     data: {
       title: foundOp.summary || operationId,
-      summary: foundOp.summary,
+      summary: foundOp.summary !== (foundOp.summary || operationId) ? foundOp.summary : undefined,
       description: foundOp.description,
       method: foundMethod as string,
       path: foundPath as string,

--- a/packages/converters/src/api-reference.ts
+++ b/packages/converters/src/api-reference.ts
@@ -1,0 +1,327 @@
+import { cleanBody, joinLines, normalizeUnicode } from "@dualmark/core";
+import type { BaseConverterConfig, CollectionEntry, Converter } from "./types.js";
+
+export interface ApiReferenceConverterConfig extends BaseConverterConfig {
+  basePath?: string;
+}
+
+export interface OpenAPISchema {
+  type?: string | string[];
+  properties?: Record<string, OpenAPISchema>;
+  items?: OpenAPISchema;
+  required?: string[];
+  description?: string;
+  $ref?: string;
+  [key: string]: unknown;
+}
+
+export interface OpenAPIParameter {
+  name: string;
+  in: string;
+  required?: boolean;
+  schema?: OpenAPISchema;
+  description?: string;
+  [key: string]: unknown;
+}
+
+export interface OpenAPIMediaType {
+  schema?: OpenAPISchema;
+  [key: string]: unknown;
+}
+
+export interface OpenAPIRequestBody {
+  description?: string;
+  content?: Record<string, OpenAPIMediaType>;
+  required?: boolean;
+  [key: string]: unknown;
+}
+
+export interface OpenAPIResponse {
+  description?: string;
+  content?: Record<string, OpenAPIMediaType>;
+  [key: string]: unknown;
+}
+
+export interface OpenAPIOperation {
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  tags?: string[];
+  parameters?: OpenAPIParameter[];
+  requestBody?: OpenAPIRequestBody;
+  responses?: Record<string, OpenAPIResponse>;
+  "x-codeSamples"?: Array<{ lang: string; source: string; label?: string }>;
+  [key: string]: unknown;
+}
+
+export interface ApiReferenceEntryData {
+  title: string;
+  summary?: string;
+  description?: string;
+  method: string;
+  path: string;
+  tags?: string[];
+  parameters?: OpenAPIParameter[];
+  requestBody?: OpenAPIRequestBody;
+  responses?: Record<string, OpenAPIResponse>;
+  codeSamples?: Array<{ lang: string; source: string; label?: string }>;
+}
+
+export function apiReferenceConverter(
+  config: ApiReferenceConverterConfig,
+): Converter<CollectionEntry<ApiReferenceEntryData>> {
+  const basePath = config.basePath ?? "/docs";
+  return (entry) => {
+    const d = entry.data;
+
+    const parts: string[] = [`# ${d.title}`];
+    if (d.summary) {
+      parts.push(`\n> ${d.summary}`);
+    }
+
+    parts.push("");
+    parts.push(`- **Method**: ${d.method.toUpperCase()}`);
+    parts.push(`- **Path**: \`${d.path}\``);
+    parts.push(`- **URL**: ${config.siteUrl}${basePath}/${entry.id}`);
+
+    if (d.description) {
+      parts.push(`\n${d.description}`);
+    }
+
+    if (d.parameters && d.parameters.length > 0) {
+      parts.push("\n## Parameters\n");
+      parts.push("| Name | In | Type | Required | Description |");
+      parts.push("| --- | --- | --- | --- | --- |");
+      for (const p of d.parameters) {
+        const typeStr = formatSchemaType(p.schema);
+        const reqStr = p.required ? "Yes" : "No";
+        const desc = p.description ? p.description.replace(/\n/g, " ") : "";
+        parts.push(`| \`${p.name}\` | ${p.in} | ${typeStr} | ${reqStr} | ${desc} |`);
+      }
+    }
+
+    if (d.requestBody) {
+      parts.push("\n## Request Body\n");
+      parts.push(formatRequestBody(d.requestBody));
+    }
+
+    if (d.responses && Object.keys(d.responses).length > 0) {
+      parts.push("\n## Responses\n");
+      parts.push(formatResponses(d.responses));
+    }
+
+    if (d.codeSamples && d.codeSamples.length > 0) {
+      parts.push("\n## Code Samples\n");
+      for (const cs of d.codeSamples) {
+        if (cs.label) parts.push(`### ${cs.label}`);
+        parts.push("```" + cs.lang);
+        parts.push(cs.source);
+        parts.push("```");
+      }
+    }
+
+    const md = joinLines(
+      ...parts,
+      entry.body && "\n---",
+      entry.body && `\n${cleanBody(entry.body)}`,
+      config.brandFooter && "\n---",
+      config.brandFooter && `\n${config.brandFooter}`,
+    );
+    return normalizeUnicode(md);
+  };
+}
+
+function formatSchemaType(schema?: OpenAPISchema): string {
+  if (!schema) return "Any";
+  if (schema.$ref && typeof schema.$ref === "string") return `\`${schema.$ref}\``;
+  let t = schema.type;
+  if (Array.isArray(t)) {
+    // OpenAPI 3.1 nullable
+    t = t.join(" | ");
+  }
+  return t ? `\`${t}\`` : "Any";
+}
+
+interface FlattenedField {
+  name: string;
+  type: string;
+  required: boolean;
+  description: string;
+}
+
+function flattenSchema(schema?: OpenAPISchema, prefix = ""): FlattenedField[] {
+  if (!schema) return [];
+  if (schema.$ref && typeof schema.$ref === "string") return [];
+
+  const fields: FlattenedField[] = [];
+  if (schema.type === "object" && schema.properties) {
+    const reqSet = new Set(schema.required || []);
+    for (const [key, prop] of Object.entries(schema.properties)) {
+      const propName = prefix ? `${prefix}.${key}` : key;
+      const typeStr = formatSchemaType(prop);
+      fields.push({
+        name: propName,
+        type: typeStr,
+        required: reqSet.has(key),
+        description: prop.description ? prop.description.replace(/\n/g, " ") : "",
+      });
+      // recurse
+      if (prop.type === "object" && prop.properties) {
+        fields.push(...flattenSchema(prop, propName));
+      } else if (prop.type === "array" && prop.items && typeof prop.items === "object") {
+        if (prop.items.type === "object" && prop.items.properties) {
+          fields.push(...flattenSchema(prop.items, `${propName}[]`));
+        }
+      }
+    }
+  } else if (schema.type === "array" && schema.items && typeof schema.items === "object") {
+    if (schema.items.type === "object" && schema.items.properties) {
+      fields.push(...flattenSchema(schema.items, `${prefix ? prefix + "[]" : "[]"}`));
+    }
+  }
+  return fields;
+}
+
+function formatRequestBody(reqBody: OpenAPIRequestBody): string {
+  let out = "";
+  if (reqBody.description) {
+    out += reqBody.description + "\n\n";
+  }
+  if (reqBody.content) {
+    for (const [mediaType, media] of Object.entries(reqBody.content)) {
+      out += `**Content-Type**: \`${mediaType}\`\n\n`;
+      if (media.schema) {
+        const fields = flattenSchema(media.schema);
+        if (fields.length > 0) {
+          out += "| Name | Type | Required | Description |\n";
+          out += "| --- | --- | --- | --- |\n";
+          for (const f of fields) {
+            const reqStr = f.required ? "Yes" : "No";
+            out += `| \`${f.name}\` | ${f.type} | ${reqStr} | ${f.description} |\n`;
+          }
+          out += "\n";
+        }
+      }
+    }
+  }
+  return out.trim();
+}
+
+function formatResponses(responses: Record<string, OpenAPIResponse>): string {
+  let out = "";
+  for (const [code, info] of Object.entries(responses)) {
+    out += `### ${code}\n\n`;
+    if (info.description) {
+      out += `${info.description}\n\n`;
+    }
+    if (info.content) {
+      for (const [mediaType, media] of Object.entries(info.content)) {
+        out += `**Content-Type**: \`${mediaType}\`\n\n`;
+        if (media.schema) {
+          const fields = flattenSchema(media.schema);
+          if (fields.length > 0) {
+            out += "| Name | Type | Required | Description |\n";
+            out += "| --- | --- | --- | --- |\n";
+            for (const f of fields) {
+              const reqStr = f.required ? "Yes" : "No";
+              out += `| \`${f.name}\` | ${f.type} | ${reqStr} | ${f.description} |\n`;
+            }
+            out += "\n";
+          }
+        }
+      }
+    }
+  }
+  return out.trim();
+}
+
+export function fromOpenAPI(spec: any, operationId: string): CollectionEntry<ApiReferenceEntryData> {
+  if (!spec || !spec.paths) throw new Error("Dualmark: Invalid OpenAPI spec");
+
+  const allOps: string[] = [];
+  let foundPath: string | null = null;
+  let foundMethod: string | null = null;
+  let foundOp: OpenAPIOperation | null = null;
+  let foundPathItem: any = null;
+
+  for (const [path, pathItem] of Object.entries(spec.paths)) {
+    for (const [method, operation] of Object.entries(pathItem as any)) {
+      if (
+        typeof operation === "object" &&
+        operation !== null &&
+        "operationId" in operation &&
+        typeof (operation as any).operationId === "string"
+      ) {
+        allOps.push((operation as any).operationId);
+        if ((operation as any).operationId === operationId) {
+          foundPath = path;
+          foundMethod = method;
+          foundOp = operation as OpenAPIOperation;
+          foundPathItem = pathItem;
+        }
+      }
+    }
+  }
+
+  if (!foundOp) {
+    throw new Error(
+      `Dualmark: operationId '${operationId}' not found. Available ids: ${allOps.join(", ")}`,
+    );
+  }
+
+  const resolveRef = (obj: any, seen = new Set<string>()): any => {
+    if (!obj || typeof obj !== "object") return obj;
+    if (obj.$ref && typeof obj.$ref === "string") {
+      if (seen.has(obj.$ref)) {
+        return { $ref: obj.$ref }; // Stop circular recursion
+      }
+      seen.add(obj.$ref);
+      let target = spec;
+      const parts = obj.$ref.replace(/^#\//, "").split("/");
+      for (const part of parts) {
+        if (target && part in target) {
+          target = target[part];
+        } else {
+          target = undefined;
+          break;
+        }
+      }
+      return target ? resolveRef(target, new Set(seen)) : obj;
+    }
+    const resolved: any = Array.isArray(obj) ? [] : {};
+    for (const [k, v] of Object.entries(obj)) {
+      resolved[k] = resolveRef(v, new Set(seen));
+    }
+    return resolved;
+  };
+
+  const pathParams = Array.isArray(foundPathItem.parameters)
+    ? foundPathItem.parameters.map((p: any) => resolveRef(p))
+    : [];
+  const opParams = Array.isArray(foundOp.parameters)
+    ? foundOp.parameters.map((p: any) => resolveRef(p))
+    : [];
+
+  const mergedParams = [...pathParams];
+  for (const p of opParams) {
+    const idx = mergedParams.findIndex((x) => x.name === p.name && x.in === p.in);
+    if (idx >= 0) mergedParams[idx] = p;
+    else mergedParams.push(p);
+  }
+
+  return {
+    id: operationId,
+    data: {
+      title: foundOp.summary || operationId,
+      summary: foundOp.summary,
+      description: foundOp.description,
+      method: foundMethod as string,
+      path: foundPath as string,
+      tags: foundOp.tags,
+      parameters: mergedParams.length > 0 ? mergedParams : undefined,
+      requestBody: resolveRef(foundOp.requestBody),
+      responses: resolveRef(foundOp.responses),
+      codeSamples: foundOp["x-codeSamples"] || [],
+    },
+  };
+}

--- a/packages/converters/src/index.ts
+++ b/packages/converters/src/index.ts
@@ -1,3 +1,9 @@
+export {
+  apiReferenceConverter,
+  fromOpenAPI,
+  type ApiReferenceConverterConfig,
+  type ApiReferenceEntryData,
+} from "./api-reference.js";
 export { blogConverter, type BlogConverterConfig, type BlogEntryData } from "./blog.js";
 export {
   caseStudyConverter,
@@ -64,6 +70,7 @@ export type {
 } from "./types.js";
 
 export const BUILT_IN_CONVERTERS = [
+  "api-reference",
   "blog",
   "case-study",
   "changelog",

--- a/packages/converters/test/converters.test.ts
+++ b/packages/converters/test/converters.test.ts
@@ -635,6 +635,24 @@ describe("apiReferenceConverter", () => {
     expect(out).toContain("- **URL**: https://acme.test/docs/get-users");
   });
 
+  it("escapes pipe characters in table cells", () => {
+    const out = convert({
+      id: "test",
+      data: {
+        title: "Test",
+        method: "get",
+        path: "/",
+        parameters: [{
+          name: "id|name",
+          in: "query",
+          description: "description|with|pipes",
+          schema: { type: ["string", "null"] }
+        }]
+      }
+    });
+    expect(out).toContain("| `id\\|name` | query | `string \\| null` | No | description\\|with\\|pipes |");
+  });
+
   it("renders parameters, request body, responses, and code samples", () => {
     const out = convert({
       id: "post-users",
@@ -703,6 +721,23 @@ describe("fromOpenAPI", () => {
     const entry = fromOpenAPI(PETSTORE_SPEC, "updatePet");
     expect(entry.data.requestBody).toBeDefined();
     expect(entry.data.requestBody!.content!["application/json"].schema!.properties!.name.type).toBe("string");
+  });
+
+  it("deduplicates summary when identical to derived title", () => {
+    const spec = {
+      openapi: "3.1.0",
+      paths: {
+        "/test": {
+          get: {
+            operationId: "getTest",
+            summary: "Get Test"
+          }
+        }
+      }
+    };
+    const entry = fromOpenAPI(spec, "getTest");
+    expect(entry.data.title).toBe("Get Test");
+    expect(entry.data.summary).toBeUndefined();
   });
 });
 

--- a/packages/converters/test/converters.test.ts
+++ b/packages/converters/test/converters.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
 import {
+  apiReferenceConverter,
+  fromOpenAPI,
+} from "../src/api-reference.js";
+import { PETSTORE_SPEC } from "./fixtures/petstore-openapi.js";
+import {
   blogConverter,
   caseStudyConverter,
   changelogConverter,
@@ -610,9 +615,101 @@ describe("docsConverter", () => {
   });
 });
 
+describe("apiReferenceConverter", () => {
+  const convert = apiReferenceConverter({ siteUrl: SITE });
+
+  it("renders basic api-reference", () => {
+    const out = convert({
+      id: "get-users",
+      data: {
+        title: "Get Users",
+        summary: "Returns all users",
+        method: "get",
+        path: "/users",
+      },
+    });
+    expect(out).toContain("# Get Users");
+    expect(out).toContain("> Returns all users");
+    expect(out).toContain("- **Method**: GET");
+    expect(out).toContain("- **Path**: `/users`");
+    expect(out).toContain("- **URL**: https://acme.test/docs/get-users");
+  });
+
+  it("renders parameters, request body, responses, and code samples", () => {
+    const out = convert({
+      id: "post-users",
+      data: {
+        title: "Post User",
+        method: "post",
+        path: "/users",
+        parameters: [
+          { name: "id", in: "query", required: true, schema: { type: "string" }, description: "User ID" },
+        ],
+        requestBody: {
+          description: "Body desc",
+          content: { "application/json": {} },
+        },
+        responses: {
+          "200": { description: "Success" },
+        },
+        codeSamples: [
+          { lang: "bash", source: "curl x" },
+        ],
+      },
+    });
+    expect(out).toContain("## Parameters");
+    expect(out).toContain("| `id` | query | `string` | Yes | User ID |");
+    expect(out).toContain("## Request Body");
+    expect(out).toContain("Body desc");
+    expect(out).toContain("**Content-Type**: `application/json`");
+    expect(out).toContain("## Responses");
+    expect(out).toContain("### 200");
+    expect(out).toContain("Success");
+    expect(out).toContain("## Code Samples");
+    expect(out).toContain("```bash\ncurl x\n```");
+  });
+});
+
+describe("fromOpenAPI", () => {
+  it("throws if operationId not found", () => {
+    expect(() => fromOpenAPI(PETSTORE_SPEC, "missingOp")).toThrowError(
+      /Dualmark: operationId 'missingOp' not found. Available ids: getPetById, updatePet/
+    );
+  });
+
+  it("extracts getPetById properly with nested refs and params", () => {
+    const entry = fromOpenAPI(PETSTORE_SPEC, "getPetById");
+    expect(entry.id).toBe("getPetById");
+    expect(entry.data.title).toBe("Find pet by ID");
+    expect(entry.data.method).toBe("get");
+    expect(entry.data.path).toBe("/pets/{petId}");
+    expect(entry.data.parameters).toHaveLength(2);
+    const tenantParam = entry.data.parameters!.find(p => p.name === "tenant");
+    expect(tenantParam?.required).toBe(true);
+
+    const res200 = entry.data.responses?.["200"];
+    expect(res200!.description).toBe("successful operation");
+    const schema = res200!.content!["application/json"].schema!;
+    expect(schema.properties!.category.properties!.parent.$ref).toBe("#/components/schemas/Category");
+    
+    // Nullable schema 3.1
+    expect(schema.properties!.nickname.type).toEqual(["string", "null"]);
+
+    expect(entry.data.codeSamples).toHaveLength(1);
+    expect(entry.data.codeSamples![0].lang).toBe("curl");
+  });
+
+  it("extracts updatePet with request body", () => {
+    const entry = fromOpenAPI(PETSTORE_SPEC, "updatePet");
+    expect(entry.data.requestBody).toBeDefined();
+    expect(entry.data.requestBody!.content!["application/json"].schema!.properties!.name.type).toBe("string");
+  });
+});
+
 describe("BUILT_IN_CONVERTERS export", () => {
   it("lists all built-in names in alphabetical order", () => {
     expect(BUILT_IN_CONVERTERS).toEqual([
+      "api-reference",
       "blog",
       "case-study",
       "changelog",

--- a/packages/converters/test/fixtures/petstore-openapi.ts
+++ b/packages/converters/test/fixtures/petstore-openapi.ts
@@ -1,0 +1,74 @@
+export const PETSTORE_SPEC = {
+  openapi: "3.1.0",
+  info: { title: "Petstore", version: "1.0.0" },
+  paths: {
+    "/pets/{petId}": {
+      parameters: [
+        { name: "petId", in: "path", required: true, schema: { type: "integer" }, description: "ID of pet to return" },
+        { name: "tenant", in: "header", required: false, schema: { type: "string" } },
+      ],
+      get: {
+        operationId: "getPetById",
+        summary: "Find pet by ID",
+        description: "Returns a single pet",
+        tags: ["pet"],
+        parameters: [
+          { name: "tenant", in: "header", required: true, schema: { type: "string" }, description: "Required at operation level" },
+        ],
+        "x-codeSamples": [{ lang: "curl", label: "cURL", source: "curl -X GET /pets/1" }],
+        responses: {
+          "200": {
+            description: "successful operation",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Pet" },
+              },
+            },
+          },
+        },
+      },
+      post: {
+        operationId: "updatePet",
+        requestBody: {
+          description: "Pet object that needs to be added",
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/PetUpdate" },
+            },
+          },
+        },
+        responses: {
+          "200": { description: "successful" },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      Pet: {
+        type: "object",
+        properties: {
+          id: { type: "integer" },
+          name: { type: "string" },
+          photoUrls: { type: "array", items: { type: "string" } },
+          category: { $ref: "#/components/schemas/Category" },
+          nickname: { type: ["string", "null"] },
+        },
+      },
+      Category: {
+        type: "object",
+        properties: {
+          id: { type: "integer" },
+          name: { type: "string" },
+          parent: { $ref: "#/components/schemas/Category" }, // Circular
+        },
+      },
+      PetUpdate: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+        },
+      },
+    },
+  },
+};

--- a/packages/nextjs/src/converter-registry.ts
+++ b/packages/nextjs/src/converter-registry.ts
@@ -4,6 +4,7 @@
  * across frameworks unchanged.
  */
 import {
+  apiReferenceConverter,
   blogConverter,
   caseStudyConverter,
   changelogConverter,
@@ -24,6 +25,7 @@ import {
 } from "@dualmark/converters";
 
 export type BuiltInConverterName =
+  | "api-reference"
   | "blog"
   | "case-study"
   | "changelog"
@@ -51,6 +53,8 @@ export function resolveBuiltInConverter(
   const basePath = `/${args.collectionName}`;
   const cfg = { ...args.baseConfig, basePath };
   switch (args.name as BuiltInConverterName) {
+    case "api-reference":
+      return apiReferenceConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "blog":
       return blogConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "case-study":
@@ -83,7 +87,7 @@ export function resolveBuiltInConverter(
       return videoConverter(cfg) as Converter<CollectionEntry<unknown>>;
     default:
       throw new Error(
-        `Dualmark: unknown built-in converter '${args.name}'. Valid names: blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, status-page, tool, video. Or pass a function.`,
+        `Dualmark: unknown built-in converter '${args.name}'. Valid names: api-reference, blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, status-page, tool, video. Or pass a function.`,
       );
   }
 }

--- a/packages/nextjs/test/converter-registry.test.ts
+++ b/packages/nextjs/test/converter-registry.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { resolveBuiltInConverter } from "../src/converter-registry.js";
+
+describe("converter-registry resolveBuiltInConverter", () => {
+  it("throws on unknown name", () => {
+    expect(() =>
+      resolveBuiltInConverter({
+        name: "unknown",
+        collectionName: "x",
+        baseConfig: { siteUrl: "https://example.com" },
+      })
+    ).toThrow(/unknown built-in converter/);
+  });
+
+  it("returns a callable converter for 'blog'", () => {
+    const conv = resolveBuiltInConverter({
+      name: "blog",
+      collectionName: "blog",
+      baseConfig: { siteUrl: "https://example.com" },
+    });
+    const out = conv({
+      id: "x",
+      data: { title: "X", publishedDate: new Date("2026-01-01T00:00:00Z") } as never,
+    });
+    expect(out).toContain("# X");
+  });
+
+  it("returns a callable converter for 'api-reference'", () => {
+    const conv = resolveBuiltInConverter({
+      name: "api-reference",
+      collectionName: "api",
+      baseConfig: { siteUrl: "https://example.com" },
+    });
+    const out = conv({
+      id: "get-users",
+      data: {
+        title: "Get Users",
+        method: "get",
+        path: "/users",
+      },
+    } as never);
+    expect(out).toContain("# Get Users");
+    expect(out).toContain("- **Method**: GET");
+    expect(out).toContain("- **Path**: `/users`");
+  });
+});

--- a/packages/sveltekit/src/converter-registry.ts
+++ b/packages/sveltekit/src/converter-registry.ts
@@ -3,6 +3,7 @@
  * `@dualmark/converters` `BUILT_IN_CONVERTERS`.
  */
 import {
+  apiReferenceConverter,
   blogConverter,
   caseStudyConverter,
   changelogConverter,
@@ -23,6 +24,7 @@ import {
 } from "@dualmark/converters";
 
 export type BuiltInConverterName =
+  | "api-reference"
   | "blog"
   | "case-study"
   | "changelog"
@@ -50,6 +52,8 @@ export function resolveBuiltInConverter(
 ): Converter<CollectionEntry<unknown>> {
   const cfg = { ...args.baseConfig, basePath: args.basePath ?? `/${args.collectionName}` };
   switch (args.name as BuiltInConverterName) {
+    case "api-reference":
+      return apiReferenceConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "blog":
       return blogConverter(cfg) as Converter<CollectionEntry<unknown>>;
     case "case-study":
@@ -82,7 +86,7 @@ export function resolveBuiltInConverter(
       return videoConverter(cfg) as Converter<CollectionEntry<unknown>>;
     default:
       throw new Error(
-        `Dualmark: unknown built-in converter '${args.name}'. Valid names: blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, status-page, tool, video. Or pass a function.`,
+        `Dualmark: unknown built-in converter '${args.name}'. Valid names: api-reference, blog, case-study, changelog, compare, docs, feature, glossary, integration, legal, pricing, pseo, status-page, tool, video. Or pass a function.`,
       );
   }
 }


### PR DESCRIPTION
## Summary

Add a new OpenAPI-aware `api-reference` converter to `@dualmark/converters` along with a `fromOpenAPI()` helper for generating AI-friendly markdown from API endpoint definitions.

Closes #14.

## Changes

* Add `apiReferenceConverter()` for rendering API endpoint documentation as structured markdown
* Add `fromOpenAPI(spec, operationId)` helper to project OpenAPI 3.x operations into the converter input shape
* Support local `$ref` resolution, path-level and operation-level parameter merging, and OpenAPI 3.1 nullable types
* Add Petstore fixture and tests covering converter output and OpenAPI extraction
* Register `"api-reference"` in Astro and Next.js converter registries and add registry coverage tests
* Update converter documentation, built-in converter listings, and adapters UI converter count
* Add a changeset for the new converter

## Type

* [ ] Bug fix (non-breaking)
* [x] New feature (non-breaking)
* [ ] Breaking change
* [ ] Spec change (requires bump in `AEO_SPEC_VERSION`)
* [ ] Docs / examples / tooling only

## Verification

* [x] `bun run build` passes
* [x] `bun run test` passes
* [x] `bun run typecheck` passes
* [ ] If touching examples: ran `dualmark verify` against the example end-to-end
* [ ] If touching `/spec/`: ran `bun run --filter dualmark-docs sync-spec` and committed the mirror

## Changeset

* [x] Added a changeset (`bun run changeset`) for any package with a user-visible change
