### PR TITLE
fix: respect explicit Accept: text/html from AI bot user agents

### DIFF
--- a/.changeset/bot-respect-explicit-accept.md
+++ b/.changeset/bot-respect-explicit-accept.md
@@ -1,0 +1,17 @@
+---
+"@dualmark/core": minor
+"@dualmark/cloudflare": patch
+"@dualmark/deno": patch
+"@dualmark/fastly": patch
+"@dualmark/netlify": patch
+"@dualmark/nextjs": patch
+"@dualmark/sveltekit": patch
+"@dualmark/vercel": patch
+"@dualmark/nuxt": patch
+---
+
+Respect an explicit `Accept: text/html` from AI bot user agents.
+
+Per AEO spec section 5, UA-based markdown negotiation must not override an explicit `Accept`. Until now every edge and framework adapter served the markdown twin whenever the request came from a known bot UA, even when that request asked for `Accept: text/html`. A search or preview crawler that sends a bot UA together with `Accept: text/html` was therefore handed `text/markdown` with `X-Robots-Tag: noindex` on the canonical URL.
+
+`@dualmark/core` now exports `shouldServeMarkdown(accept, isBot)`, which keeps the UA-based markdown extension but defers to RFC 7231 negotiation when the client states a concrete format preference. All adapters use it, so a bot UA now stays on HTML when it explicitly requests `text/html`, while `Accept: */*`, no `Accept`, and `Accept: text/markdown` behave exactly as before.

--- a/packages/cloudflare/src/worker.ts
+++ b/packages/cloudflare/src/worker.ts
@@ -2,6 +2,7 @@ import {
   detectAIBot,
   estimateTokens,
   negotiateFormat,
+  shouldServeMarkdown,
   toMarkdownPath,
 } from "@dualmark/core";
 import type {
@@ -170,7 +171,7 @@ export function createAEOWorker<Env extends MinimalEnv = MinimalEnv>(
           );
         }
 
-        const serveMarkdown = bot.isBot || fmt === "markdown";
+        const serveMarkdown = shouldServeMarkdown(accept, bot.isBot);
 
         if (serveMarkdown) {
           const mdPath = toMarkdownPath(pathname);

--- a/packages/cloudflare/test/worker.test.ts
+++ b/packages/cloudflare/test/worker.test.ts
@@ -83,6 +83,21 @@ describe("createAEOWorker — markdown serving", () => {
     expect(await res.text()).toBe("# Post 1\n\nBody.");
   });
 
+  it("keeps a bot UA on HTML when it explicitly requests text/html (spec §5)", async () => {
+    const worker = createAEOWorker({
+      upstream: makeUpstream(() => new Response("html", { headers: { "Content-Type": "text/html" } })),
+    });
+    const req = new Request("https://acme.test/blog/post-1", {
+      headers: { "user-agent": "GPTBot/1.0", accept: "text/html" },
+    });
+    const res = await worker.fetch(req, env, makeCtx());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(res.headers.get("content-type")).not.toContain("text/markdown");
+    expect(res.headers.get("x-robots-tag")).toBeNull();
+    expect(await res.text()).toBe("html");
+  });
+
   it("serves markdown when Accept: text/markdown (no bot UA)", async () => {
     const worker = createAEOWorker({
       upstream: makeUpstream(() => new Response("html", { headers: { "Content-Type": "text/html" } })),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export {
   parseAcceptHeader,
   mediaTypeMatches,
   negotiateFormat,
+  shouldServeMarkdown,
   type ParsedMediaType,
 } from "./negotiation.js";
 

--- a/packages/core/src/negotiation.ts
+++ b/packages/core/src/negotiation.ts
@@ -125,3 +125,25 @@ export function negotiateFormat<T extends string = "html" | "markdown">(
 
   return best === null ? null : (best as { fmt: T; q: number; idx: number }).fmt;
 }
+
+/**
+ * Decide whether a request should be served the markdown twin instead of HTML.
+ *
+ * This encodes the AEO spec §5 rule for UA-based markdown: a known AI bot MAY
+ * receive markdown, but "UA detection MUST NOT override an explicit `Accept`".
+ * Markdown is served when either:
+ *
+ *   1. RFC 7231 negotiation on the `Accept` header already picks markdown, or
+ *   2. the request is from a known AI bot AND markdown is at least as
+ *      acceptable as HTML for that `Accept` header.
+ *
+ * Case 2 is checked by negotiating with markdown listed first, so a tie (a
+ * wildcard Accept, or no Accept at all) resolves to markdown for bots, while an
+ * explicit `Accept: text/html` (where HTML strictly outranks markdown, or
+ * markdown is not acceptable at all) keeps the bot on HTML.
+ */
+export function shouldServeMarkdown(accept: string, isBot: boolean): boolean {
+  if (negotiateFormat(accept) === "markdown") return true;
+  if (!isBot) return false;
+  return negotiateFormat(accept, ["markdown", "html"]) === "markdown";
+}

--- a/packages/core/test/negotiation.test.ts
+++ b/packages/core/test/negotiation.test.ts
@@ -4,6 +4,7 @@ import {
   parseAcceptHeader,
   mediaTypeMatches,
   negotiateFormat,
+  shouldServeMarkdown,
   registerFormat,
   getRegisteredFormats,
 } from "../src/negotiation.js";
@@ -294,5 +295,34 @@ describe("parseAcceptHeader — property tests", () => {
       }),
       { numRuns: 200 },
     );
+  });
+});
+
+describe("shouldServeMarkdown", () => {
+  it("serves markdown when Accept explicitly negotiates markdown (any UA)", () => {
+    expect(shouldServeMarkdown("text/markdown", false)).toBe(true);
+    expect(shouldServeMarkdown("text/markdown", true)).toBe(true);
+  });
+
+  it("serves markdown to a bot with no Accept or a wildcard Accept", () => {
+    expect(shouldServeMarkdown("", true)).toBe(true);
+    expect(shouldServeMarkdown("*/*", true)).toBe(true);
+    expect(shouldServeMarkdown("text/*", true)).toBe(true);
+  });
+
+  it("keeps a bot on HTML when it explicitly requests text/html (spec §5)", () => {
+    // "UA detection MUST NOT override an explicit Accept"
+    expect(shouldServeMarkdown("text/html", true)).toBe(false);
+  });
+
+  it("keeps a bot on HTML when HTML strictly outranks markdown", () => {
+    // Browser-like Accept from a bot UA: html=1.0 > markdown(via wildcard)=0.8
+    expect(shouldServeMarkdown("text/html,application/xhtml+xml,*/*;q=0.8", true)).toBe(false);
+  });
+
+  it("does not serve markdown to a non-bot unless Accept asks for it", () => {
+    expect(shouldServeMarkdown("", false)).toBe(false);
+    expect(shouldServeMarkdown("*/*", false)).toBe(false);
+    expect(shouldServeMarkdown("text/html", false)).toBe(false);
   });
 });

--- a/packages/deno/src/handler.ts
+++ b/packages/deno/src/handler.ts
@@ -2,6 +2,7 @@ import {
   detectAIBot,
   estimateTokens,
   negotiateFormat,
+  shouldServeMarkdown,
   toMarkdownPath,
 } from "@dualmark/core";
 import type {
@@ -167,7 +168,7 @@ export function createAEOHandler(options: CreateAEOHandlerOptions): AEODenoHandl
         );
       }
 
-      const serveMarkdown = bot.isBot || fmt === "markdown";
+      const serveMarkdown = shouldServeMarkdown(accept, bot.isBot);
 
       if (serveMarkdown) {
         const mdPath = toMarkdownPath(pathname);

--- a/packages/deno/test/handler.test.ts
+++ b/packages/deno/test/handler.test.ts
@@ -48,6 +48,21 @@ describe("createAEOHandler — markdown serving", () => {
     expect(await res.text()).toBe("# Post 1\n\nBody.");
   });
 
+  it("keeps a bot UA on HTML when it explicitly requests text/html (spec §5)", async () => {
+    const handler = createAEOHandler({
+      upstream: makeUpstream(files),
+    });
+    const req = new Request("https://acme.test/blog/post-1", {
+      headers: { "user-agent": "GPTBot/1.0", accept: "text/html" },
+    });
+    const res = await handler(req, makeInfo());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(res.headers.get("content-type")).not.toContain("text/markdown");
+    expect(res.headers.get("x-robots-tag")).toBeNull();
+    expect(await res.text()).toBe("<html>Post 1</html>");
+  });
+
   it("serves markdown when Accept: text/markdown (no bot UA)", async () => {
     const handler = createAEOHandler({
       upstream: makeUpstream(files),

--- a/packages/fastly/src/handler.ts
+++ b/packages/fastly/src/handler.ts
@@ -2,6 +2,7 @@ import {
   detectAIBot,
   estimateTokens,
   negotiateFormat,
+  shouldServeMarkdown,
   toMarkdownPath,
 } from "@dualmark/core";
 import type {
@@ -172,7 +173,7 @@ export function createAEORequestHandler(options: CreateAEOFastlyOptions): AEOFas
         );
       }
 
-      const serveMarkdown = bot.isBot || fmt === "markdown";
+      const serveMarkdown = shouldServeMarkdown(accept, bot.isBot);
 
       if (serveMarkdown) {
         const mdPath = toMarkdownPath(pathname);

--- a/packages/fastly/test/handler.test.ts
+++ b/packages/fastly/test/handler.test.ts
@@ -87,6 +87,22 @@ describe("Fastly Adapter", () => {
       expect(fetch).toHaveBeenCalledWith(expect.any(Request), { backend: "markdown_backend" });
     });
 
+    it("keeps a bot UA on HTML when it explicitly requests text/html (spec §5)", async () => {
+      const handler = createAEORequestHandler({
+        backend: "default_backend",
+        markdownBackend: "markdown_backend"
+      });
+      const req = new Request("https://acme.test/blog/post-1", {
+        headers: { "user-agent": "GPTBot/1.0", accept: "text/html" },
+      });
+      const res = await handler(req);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/html");
+      expect(res.headers.get("content-type")).not.toContain("text/markdown");
+      expect(res.headers.get("x-robots-tag")).toBeNull();
+      expect(await res.text()).toBe("<html>Post 1</html>");
+    });
+
     it("uses custom tokenizer when provided", async () => {
       const handler = createAEORequestHandler({
         backend: "default_backend",

--- a/packages/netlify/src/worker.ts
+++ b/packages/netlify/src/worker.ts
@@ -2,6 +2,7 @@ import {
   detectAIBot,
   estimateTokens,
   negotiateFormat,
+  shouldServeMarkdown,
   toMarkdownPath,
 } from "@dualmark/core";
 import type {
@@ -181,7 +182,7 @@ export function createAEOWorker(
         );
       }
 
-      if (bot.isBot || fmt === "markdown") {
+      if (shouldServeMarkdown(accept, bot.isBot)) {
         const mdPathname = toMarkdownPath(pathname);
         const assetRes = await fetchMd(assets, url.origin, mdPathname, subrequestHeader);
 

--- a/packages/netlify/test/worker.test.ts
+++ b/packages/netlify/test/worker.test.ts
@@ -62,6 +62,19 @@ describe("createAEOWorker — markdown serving", () => {
     expect(await res.text()).toBe("# Post 1\n\nBody.");
   });
 
+  it("keeps a bot UA on HTML when it explicitly requests text/html (spec §5)", async () => {
+    const worker = createAEOWorker({ assets });
+    const req = new Request("https://acme.test/blog/post-1", {
+      headers: { "user-agent": "GPTBot/1.0", accept: "text/html" },
+    });
+    const res = await worker(req, makeContext());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(res.headers.get("content-type")).not.toContain("text/markdown");
+    expect(res.headers.get("x-robots-tag")).toBeNull();
+    expect(await res.text()).toBe("<html>ok</html>");
+  });
+
   it("serves markdown when Accept: text/markdown (no bot UA)", async () => {
     const worker = createAEOWorker({ assets });
     const req = new Request("https://acme.test/blog/post-1", {

--- a/packages/nextjs/src/middleware.ts
+++ b/packages/nextjs/src/middleware.ts
@@ -1,4 +1,4 @@
-import { detectAIBot, negotiateFormat, toMarkdownPath } from "@dualmark/core";
+import { detectAIBot, negotiateFormat, shouldServeMarkdown, toMarkdownPath } from "@dualmark/core";
 import { resolveConfig } from "./config-validation.js";
 import type { DualmarkNextConfig, ResolvedDualmarkNextConfig } from "./types.js";
 
@@ -119,7 +119,7 @@ export function handleRequest(
   const bot = detectAIBot(ua);
   const fmt = negotiateFormat(accept);
 
-  if (bot.isBot || fmt === "markdown") {
+  if (shouldServeMarkdown(accept, bot.isBot)) {
     const url = request.nextUrl.clone();
     url.pathname = toInternalMarkdownPath(pathname, internalNamespace);
     return NextResponse.rewrite(url);

--- a/packages/nextjs/test/middleware.test.ts
+++ b/packages/nextjs/test/middleware.test.ts
@@ -76,6 +76,17 @@ describe("handleRequest — bot/Accept negotiation", () => {
     expect(res.headers.get("x-middleware-rewrite")).toBe("https://example.com/md/blog/hello");
   });
 
+  it("keeps a bot UA on HTML when it explicitly requests text/html (spec §5)", () => {
+    const req = makeReq("https://example.com/blog/hello", {
+      "user-agent": "GPTBot/1.0",
+      accept: "text/html",
+    });
+    const res = handleRequest(req, FakeNextResponse, resolved);
+    expect(res.headers.get("x-middleware-rewrite")).toBeNull();
+    expect(res.headers.get("x-middleware-next")).toBe("1");
+    expect(res.headers.get("link")).toContain('</blog/hello.md>; rel="alternate"; type="text/markdown"');
+  });
+
   it("rewrites to /md/<path> for Accept: text/markdown", () => {
     const req = makeReq("https://example.com/blog/hello", { accept: "text/markdown" });
     const res = handleRequest(req, FakeNextResponse, resolved);

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -252,7 +252,7 @@ function getMiddlewareCode(
 ) {
   return `
 import { defineEventHandler } from 'h3';
-import { negotiateFormat, detectAIBot, toMarkdownPath, markdownResponse, listingToMarkdown } from '@dualmark/core';
+import { negotiateFormat, shouldServeMarkdown, detectAIBot, toMarkdownPath, markdownResponse, listingToMarkdown } from '@dualmark/core';
 import { resolveBuiltInConverter } from ${JSON.stringify(resolverPath)};
 ${collectionCode}
 ${tokenizerDecl}const dualmarkConfig = ${dualmarkConfigStr};
@@ -284,7 +284,7 @@ export default defineEventHandler(async (event) => {
     return new Response('Not Acceptable', { status: 406 });
   }
 
-  const serveMarkdown = isMd || botInfo.isBot || format === 'markdown';
+  const serveMarkdown = isMd || shouldServeMarkdown(accept, botInfo.isBot);
 
   if (!serveMarkdown) {
     // Regular HTML request — pass through to Nuxt SSR.

--- a/packages/nuxt/src/runtime/server/endpoints/middleware.ts
+++ b/packages/nuxt/src/runtime/server/endpoints/middleware.ts
@@ -1,5 +1,5 @@
 import { defineEventHandler, getRequestHeader } from 'h3';
-import { negotiateFormat, detectAIBot, markdownResponse, listingToMarkdown } from '@dualmark/core';
+import { negotiateFormat, shouldServeMarkdown, detectAIBot, markdownResponse, listingToMarkdown } from '@dualmark/core';
 import type { Converter, CollectionEntry } from '@dualmark/converters';
 import type { H3Event } from 'h3';
 
@@ -38,7 +38,7 @@ export function makeCollectionMiddleware<TEntry = CollectionEntry<unknown>>(
       return new Response('Not Acceptable', { status: 406 });
     }
 
-    const serveMarkdown = isMd || botInfo.isBot || format === 'markdown';
+    const serveMarkdown = isMd || shouldServeMarkdown(accept, botInfo.isBot);
 
     if (!serveMarkdown) {
       // Regular HTML request — pass through to Nuxt SSR.

--- a/packages/nuxt/test/middleware.test.ts
+++ b/packages/nuxt/test/middleware.test.ts
@@ -78,6 +78,15 @@ describe('makeCollectionMiddleware content negotiation', () => {
     expect(await res.text()).toContain('# Post 1');
   });
 
+  it('keeps a bot UA on HTML when it explicitly requests text/html (spec §5)', async () => {
+    const event = createFakeEvent('/blog/post-1', {
+      'user-agent': 'GPTBot/1.0',
+      accept: 'text/html',
+    });
+    const res = await handler(event);
+    expect(res).toBeUndefined();
+  });
+
   it('returns 404 Response for non-existent markdown slugs', async () => {
     const event = createFakeEvent('/blog/non-existent.md');
     const res = await handler(event) as Response;

--- a/packages/sveltekit/src/handle.ts
+++ b/packages/sveltekit/src/handle.ts
@@ -2,6 +2,7 @@ import {
   detectAIBot,
   injectMarkdownAlternateLink,
   negotiateFormat,
+  shouldServeMarkdown,
   toMarkdownPath,
 } from "@dualmark/core";
 import { resolveConfig } from "./config-validation.js";
@@ -68,7 +69,7 @@ export async function handleRequest(
     const bot = detectAIBot(userAgent);
     const format = negotiateFormat(accept);
 
-    if (bot.isBot || format === "markdown") {
+    if (shouldServeMarkdown(accept, bot.isBot)) {
       return fetchMarkdownTwin(event, pathname);
     }
 

--- a/packages/sveltekit/test/handle.test.ts
+++ b/packages/sveltekit/test/handle.test.ts
@@ -49,6 +49,29 @@ describe("handleRequest", () => {
     expect(fetch).toHaveBeenCalledWith("/posts/hello.md", expect.any(Object));
   });
 
+  it("keeps a bot UA on HTML when it explicitly requests text/html (spec §5)", async () => {
+    const fetch = vi.fn(async () => new Response("# Bot Markdown"));
+    const resolve = vi.fn(
+      async () =>
+        new Response("<html></html>", { headers: { "Content-Type": "text/html" } }),
+    );
+    const response = await handleRequest(
+      makeEvent(
+        "https://example.com/posts/hello",
+        { "user-agent": "GPTBot/1.0", accept: "text/html" },
+        fetch,
+      ),
+      resolve,
+      resolved,
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(resolve).toHaveBeenCalled();
+    expect(response.headers.get("link")).toContain(
+      '</posts/hello.md>; rel="alternate"; type="text/markdown"',
+    );
+  });
+
   it("returns 406 when Accept rules out HTML and markdown", async () => {
     const response = await handleRequest(
       makeEvent("https://example.com/posts/hello", { accept: "image/png" }),

--- a/packages/vercel/src/middleware.ts
+++ b/packages/vercel/src/middleware.ts
@@ -1,4 +1,4 @@
-import { detectAIBot, estimateTokens, negotiateFormat, toMarkdownPath } from "@dualmark/core";
+import { detectAIBot, estimateTokens, negotiateFormat, shouldServeMarkdown, toMarkdownPath } from "@dualmark/core";
 import type { AIRequestInfo, MissInfo } from "./types.js";
 import type { CreateAEOMiddlewareOptions, VercelEdgeContext } from "./types.js";
 
@@ -187,7 +187,7 @@ export function createAEOMiddleware(
         });
       }
 
-      const serveMarkdown = bot.isBot || fmt === "markdown";
+      const serveMarkdown = shouldServeMarkdown(accept, bot.isBot);
 
       if (serveMarkdown) {
         const mdPath = toMarkdownPath(pathname);

--- a/packages/vercel/test/middleware.test.ts
+++ b/packages/vercel/test/middleware.test.ts
@@ -53,6 +53,24 @@ describe("createAEOMiddleware — markdown serving", () => {
     expect(await res.text()).toBe("# Post 1\n\nBody.");
   });
 
+  it("keeps a bot UA on HTML when it explicitly requests text/html (spec §5)", async () => {
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(
+        () => new Response("html", { headers: { "Content-Type": "text/html" } }),
+      ),
+      fetchAsset,
+    });
+    const req = new Request("https://acme.test/blog/post-1", {
+      headers: { "user-agent": "GPTBot/1.0", accept: "text/html" },
+    });
+    const res = await middleware(req, makeCtx());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    expect(res.headers.get("content-type")).not.toContain("text/markdown");
+    expect(res.headers.get("x-robots-tag")).toBeNull();
+    expect(await res.text()).toBe("html");
+  });
+
   it("serves markdown when Accept: text/markdown (no bot UA)", async () => {
     const middleware = createAEOMiddleware({
       upstream: makeUpstream(


### PR DESCRIPTION
## Summary

Bot user agents currently get the markdown twin even when they explicitly ask for `Accept: text/html`. The AEO spec says the opposite should happen, so this fixes the adapters to honor an explicit Accept while keeping the existing bot behavior for everything else.

Closes #69.

## Changes

- Add `shouldServeMarkdown(accept, isBot)` to `@dualmark/core`. It serves markdown when RFC 7231 negotiation already picks markdown, or when the request is from a known bot and markdown is at least as acceptable as HTML. It checks the second case by negotiating with markdown listed first, so a tie (wildcard or empty Accept) resolves to markdown for bots, while an explicit `Accept: text/html` keeps the bot on HTML.
- Use the helper in the cloudflare, deno, fastly, netlify, nextjs, sveltekit, vercel and nuxt adapters, replacing the `bot.isBot || fmt === "markdown"` check that ignored the Accept header for bots.
- Add a regression test in each adapter: a `GPTBot/1.0` UA with `Accept: text/html` now receives HTML, not a noindex markdown body.
- Add unit tests for the helper in `@dualmark/core`.

Behavior is unchanged for `Accept: */*`, no `Accept`, and `Accept: text/markdown`, so the existing conformance scores and bot handling stay the same.

## Type

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Spec change (requires bump in `AEO_SPEC_VERSION`)
- [ ] Docs / examples / tooling only

## Verification

- [x] `bun run build` passes
- [x] `bun run test` passes (541 tests across the packages)
- [x] `bun run typecheck` passes
- [ ] If touching examples: ran `dualmark verify` against the example end-to-end (no examples touched)
- [ ] If touching `/spec/`: ran sync-spec and committed the mirror (no spec files touched)

## Changeset

- [x] Added a changeset (`@dualmark/core` minor, adapters patch)

---

cc @thepushkaraj @aagarwal1012 for a look when you have a minute(file change might look scary but indeed needed have a look). Happy to adjust the approach if you would rather keep the decision logic inside each adapter instead of a shared core helper.
