### PR TITLE
docs: add AEO 1.1 draft spec

### DIFF
--- a/spec/v1.1-draft.md
+++ b/spec/v1.1-draft.md
@@ -1,0 +1,390 @@
+# AEO Specification v1.1 Draft
+
+- **Status:** Draft for discussion (June 2026)
+- **Extends:** [AEO Specification v1.0](./README.md)
+- **Editors:** The Dualmark Working Group (Dodo Payments)
+
+This document proposes backward-compatible extensions to AEO Spec v1.0 for AI-oriented markdown discovery, section-level deep links, and structured extraction hints. AEO v1.1 aims to improve AI discovery, intra-document citation, and structured extraction while preserving all v1.0 conformance profiles.
+
+## 0. Status of this Document
+
+This document is a **draft proposal**, not a finalized conformance target. It has not been adopted by a standards body and is not yet required by the reference implementation. Its primary audience is implementors serving content to interactive assistants, AI search crawlers, offline indexers, and developer tools that retrieve markdown twins for citation or extraction.
+
+The keywords **MUST**, **MUST NOT**, **SHOULD**, **SHOULD NOT**, and **MAY** in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+## 1. Compatibility with AEO v1.0
+
+A server conforming to [AEO Spec v1.0](./README.md) **MUST** remain conformant under this draft. The features in this document are additive extensions.
+
+Unless a future finalized v1.1 specification says otherwise:
+
+- Existing markdown twins do not need to change.
+- Existing Basic, Standard, and Advanced conformance claims remain valid.
+- Implementations **MAY** adopt `/sitemap.md`, section anchors, and structured-data hints independently.
+- Clients **SHOULD** gracefully handle servers that implement only a subset of these features and **MUST NOT** assume that the presence of one v1.1 feature implies the others.
+- Package implementations are expected to land in follow-up work after the draft receives feedback.
+
+## 2. Terminology
+
+- **Markdown Sitemap**: A markdown document, conventionally served at `/sitemap.md`, that lists canonical markdown twin URLs for AI agents.
+- **Markdown Sitemap Entry**: One listed markdown twin in a Markdown Sitemap, optionally accompanied by metadata such as last-modified time and estimated token count.
+- **Section Anchor**: A stable fragment identifier for an H2 or H3 section in a markdown twin, such as `#faq-refunds`.
+- **Structured-Data Hint**: An opt-in fenced block in a markdown twin that mirrors schema.org JSON-LD or another machine-readable structured-data shape.
+- **Canonical Markdown Twin URL**: The preferred `.md` URL for a page, following the v1.0 convention in [content-negotiation.md §6](./content-negotiation.md#6-canonical-markdown-url).
+
+## 3. Markdown Sitemap (`/sitemap.md`)
+
+The Markdown Sitemap is a markdown sibling to `sitemap.xml`. It gives AI agents a simple, text-first way to discover markdown twins without parsing XML or guessing URL patterns.
+
+A server **MAY** publish a Markdown Sitemap at `/sitemap.md`. If published, the Markdown Sitemap **SHOULD** list canonical markdown twin URLs rather than HTML URLs.
+
+### 3.1 Relationship to `sitemap.xml` and `llms.txt`
+
+The Markdown Sitemap does not replace `sitemap.xml` or `llms.txt`.
+
+- `sitemap.xml` remains the standard machine-readable sitemap format for crawlers.
+- `llms.txt` is a curated AI-facing content guide, as described in [llms-txt-extensions.md](./llms-txt-extensions.md).
+- `/sitemap.md` is a mechanical inventory of markdown twins.
+
+When both `llms.txt` and `/sitemap.md` exist, `llms.txt` **SHOULD** link to canonical HTML URLs and `/sitemap.md` **SHOULD** link to canonical markdown twin URLs.
+
+Publishers **SHOULD** generate `/sitemap.md` from the same route and freshness source of truth as `sitemap.xml` to avoid divergent URL or `last-modified` metadata.
+
+### 3.2 Format
+
+A Markdown Sitemap **SHOULD** begin with an H1 heading and then list markdown twin entries as markdown links. Headings are presentational; each bullet entry is the unit parsers should treat as one markdown twin.
+
+The minimal machine-oriented grammar is:
+
+1. A bullet line beginning with `- ` starts a new Markdown Sitemap Entry.
+2. The bullet line **SHOULD** contain a markdown link whose target is the canonical markdown twin URL.
+3. Indented lines, by at least two spaces or one tab, containing a `key: value` pair belong to that entry until the next bullet line or heading. Keys **SHOULD** use lowercase ASCII letters, digits, and hyphens. Values **MAY** be unquoted or quoted strings.
+4. Blank lines between entries are allowed. Parsers **MUST** tolerate blank lines between metadata lines.
+
+Each entry **SHOULD** include:
+
+- A human-readable title.
+- A canonical markdown twin URL.
+- `last-modified`, as an ISO 8601 date (`YYYY-MM-DD`) or datetime (`YYYY-MM-DDTHH:mm:ssZ`).
+- `tokens`, as a base-10 integer greater than or equal to `0`.
+
+Example:
+
+```markdown
+# Sitemap
+
+- [Pricing](/pricing.md)
+  - last-modified: 2026-05-06
+  - tokens: 842
+- [Refund FAQ](/faq/refunds.md)
+  - last-modified: 2026-05-01T12:30:00Z
+  - tokens: 391
+```
+
+Publishers **MAY** group entries with H2 headings when helpful for readability:
+
+```markdown
+# Sitemap
+
+## Product
+
+- [Pricing](/pricing.md)
+  - last-modified: 2026-05-06
+  - tokens: 842
+
+## Support
+
+- [Refund FAQ](/faq/refunds.md)
+  - last-modified: 2026-05-01T12:30:00Z
+  - tokens: 391
+```
+
+Parsers **SHOULD** support both flat and grouped forms. Servers targeting minimal clients **SHOULD** prefer the flat form, while publishers **MAY** use grouping for human readability.
+
+### 3.3 Metadata semantics
+
+The `last-modified` value **SHOULD** describe the content freshness of the markdown twin, not merely the time the sitemap was generated. Clients **MAY** normalize datetimes to date-only values for indexing or cache bucketing.
+
+The `tokens` value **SHOULD** use the same estimation model as `X-Markdown-Tokens` where possible. Token counts are informational. Clients **MAY** use them for context budgeting. Clients **MUST NOT** rely on them for billing, authorization, or access control.
+
+If `tokens` is absent, clients **MUST** treat the token count as unknown, not as `0`. Clients **MAY** skip token-budget-based routing or fetch the markdown twin to read `X-Markdown-Tokens` when token metadata is missing.
+
+Each canonical HTML URL **SHOULD** have a single canonical markdown twin URL in `/sitemap.md`. Legacy or alternate markdown URLs **SHOULD NOT** be listed unless they are intentionally discoverable. Publishers **MAY** use an extension metadata key such as `canonical: true` while this draft settles canonicalization details.
+
+A Markdown Sitemap **MAY** contain absolute URLs, including URLs on language subdomains or alternate hosts, when those URLs are part of the same site inventory. For simpler cache and ownership semantics, each origin **SHOULD** publish its own `/sitemap.md` where practical.
+
+Parsers **SHOULD** ignore unknown metadata keys. Publishers **MAY** add extra keys in future drafts or implementation-specific extensions.
+
+### 3.4 Response headers
+
+A Markdown Sitemap response **SHOULD** use one of the following content types:
+
+- `text/markdown; charset=utf-8`
+- `text/plain; charset=utf-8`
+
+A Markdown Sitemap response **SHOULD** set `X-Robots-Tag: noindex` and **MAY** set `Cache-Control: public, max-age=3600`. The `noindex` directive controls search-result visibility; it does not prevent AI agents or crawlers from fetching the sitemap for discovery.
+
+### 3.5 Shards and sitemap indexes
+
+Large sites **MAY** publish Markdown Sitemap shards such as `/sitemap-docs.md` and `/sitemap-blog.md`. If shards are used, `/sitemap.md` **SHOULD** act as the discoverable index that links to every shard. Clients **SHOULD NOT** be required to guess shard names.
+
+Example sitemap index:
+
+```markdown
+# Sitemap
+
+## Sitemap Shards
+
+- [Documentation sitemap](/sitemap-docs.md)
+- [Blog sitemap](/sitemap-blog.md)
+```
+
+Publishers **SHOULD** keep each shard small enough for practical parsing by AI agents. A future draft may define entry-count or token-count limits.
+
+## 4. Section Anchor Convention
+
+Section anchors let AI agents cite or retrieve a specific answer within a markdown twin:
+
+```txt
+/pricing.md#faq-refunds
+```
+
+Markdown processors do not consistently generate heading IDs. AEO v1.1 therefore defines a stable convention for publishers and consumers.
+
+### 4.1 Anchor stability
+
+Publishers **SHOULD** provide stable anchors for H2 and H3 sections that are likely to be cited by AI agents, especially FAQ, pricing, comparison, policy, and documentation sections.
+
+Publishers **SHOULD** keep section anchors stable across content edits when the semantic meaning of the section has not changed.
+
+### 4.2 Explicit anchors
+
+For maximum compatibility, publishers **SHOULD** emit explicit HTML anchors immediately before the relevant heading:
+
+```markdown
+<a id="faq-refunds"></a>
+
+### Can I get a refund?
+```
+
+CommonMark permits raw HTML, and explicit anchors avoid relying on renderer-specific heading slug algorithms.
+
+When an explicit anchor such as `<a id="..."></a>` or `<a name="..."></a>` is present immediately before or within a heading, consumers **MUST** prioritize that explicit identifier over any fallback slug. The fallback slug algorithm **MUST NOT** create a competing canonical anchor for a heading that already has an explicit anchor.
+
+Publishers **MAY** define multiple explicit anchors immediately before a heading to preserve legacy aliases:
+
+```markdown
+<a id="refunds"></a><a id="faq-refunds"></a>
+
+### Can I get a refund?
+```
+
+Consumers **SHOULD** honor all explicit aliases.
+
+Publishers **SHOULD NOT** rely only on non-standard heading attribute syntax such as:
+
+```markdown
+### Can I get a refund? {#faq-refunds}
+```
+
+unless they know their markdown renderer and AI consumers support that syntax. Consumers **MAY** parse and honor this syntax when their toolchain supports it, but explicit HTML anchors remain the portable form.
+
+### 4.3 Fallback slug algorithm
+
+When explicit anchors are not present, consumers **MAY** derive anchors from H2 and H3 text using the following fallback algorithm. Fallback anchors for H4, H5, and H6 headings are optional and implementation-defined.
+
+1. Strip inline markdown formatting.
+2. Convert text to lowercase.
+3. Trim leading and trailing whitespace.
+4. Replace each run of non-alphanumeric characters with `-`. For this algorithm, alphanumeric characters **MUST** include Unicode letters and numbers.
+5. Trim leading and trailing `-` characters.
+6. If the result is empty, use `section-N`, where `N` is the 1-based index of the H2/H3 heading in document order.
+7. Append `-2`, `-3`, and so on for duplicate anchors in document order. The first occurrence has no numeric suffix; the second occurrence receives `-2`.
+
+Examples:
+
+| Heading                   | Anchor                |
+| ------------------------- | --------------------- |
+| `## Refunds`              | `#refunds`            |
+| `### Can I get a refund?` | `#can-i-get-a-refund` |
+| `## 🚀 Getting Started`   | `#getting-started`    |
+| `## 🚀`                   | `#section-1`          |
+| First `## Pricing`        | `#pricing`            |
+| Second `## Pricing`       | `#pricing-2`          |
+
+Publishers **SHOULD** prefer explicit ASCII anchors for maximum compatibility, especially when they want semantic prefixes such as `faq-`. Publishers **MAY** use percent-encoded or Unicode anchors when required by their content, but consumers are not required by this draft to normalize every Unicode slugging strategy.
+
+Fragment identifiers are case-sensitive for purposes of this draft. Publishers **SHOULD** emit lowercase anchors and **SHOULD** avoid very long anchors when a shorter stable identifier would communicate the same section.
+
+## 5. Structured-Data Hints
+
+Structured-data hints let markdown twins expose schema-like facts without requiring HTML `<script type="application/ld+json">` blocks.
+
+Structured-data hints are optional. Publishers **MAY** include them when they improve extraction quality for AI agents.
+
+### 5.1 Fenced block syntax
+
+The preferred draft syntax is a fenced code block with the language identifier `aeo-schema`:
+
+````markdown
+```aeo-schema
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": []
+}
+```
+````
+
+The fenced block body **MUST** contain valid JSON. When the hint mirrors schema.org, it **SHOULD** use JSON-LD-compatible keys such as `@context` and `@type`.
+
+Publishers **MAY** use `jsonld`, `json-ld`, or `application/ld+json` as fenced block language aliases when reusing existing tooling. Consumers **SHOULD** treat those aliases as structured-data hints when the block body is a JSON object containing JSON-LD keys such as `@context` and `@type`.
+
+When not mirroring schema.org, publishers **MAY** use other JSON structures inside `aeo-schema`, but **SHOULD** document those structures for consumers.
+
+A markdown twin **MAY** contain multiple structured-data hint blocks. Consumers **SHOULD** parse all recognized hint blocks in document order and treat the parsed objects as a combined collection, similar to a JSON-LD `@graph`, rather than letting later blocks overwrite earlier blocks by default.
+
+If a structured-data hint contains invalid JSON, consumers **MUST NOT** fail the parsing of the markdown twin. Consumers **SHOULD** ignore the malformed block, continue parsing the rest of the document, and **MAY** expose validation warnings in development or conformance tooling.
+
+Consumers **MAY** ignore structured-data hints they do not understand.
+
+### 5.2 Content consistency
+
+Structured-data hints **MUST NOT** contradict the visible markdown content. Visible markdown is the canonical source of truth. If a consumer detects a direct conflict between visible markdown and a structured-data hint, it **SHOULD** prefer the visible markdown and **MAY** discard the conflicting hint.
+
+Publishers **SHOULD NOT** include facts in structured-data hints that are absent from, or materially different from, the visible markdown twin. Examples of contradictory hints include:
+
+- A `price` value that differs from the pricing table.
+- A refund policy answer that differs from the FAQ section.
+- A `dateModified` value that is newer than the content actually served.
+
+Structured-data hints **MAY** be partial. Publishers are not required to represent every visible fact in a hint block. Consumers **SHOULD NOT** reject an otherwise valid hint solely because optional schema.org fields are missing.
+
+### 5.3 Examples
+
+FAQ hint:
+
+````markdown
+```aeo-schema
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Can I get a refund?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Refunds are available within 14 days for eligible purchases."
+      }
+    }
+  ]
+}
+```
+````
+
+Article hint:
+
+````markdown
+```aeo-schema
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "How AI Agents Read Markdown Twins",
+  "dateModified": "2026-05-06",
+  "author": {
+    "@type": "Organization",
+    "name": "Dodo Payments"
+  }
+}
+```
+````
+
+Software application hint:
+
+````markdown
+```aeo-schema
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "Dualmark",
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "Any"
+}
+```
+````
+
+Breadcrumb hint:
+
+````markdown
+```aeo-schema
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Docs",
+      "item": "https://example.com/docs"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Payments",
+      "item": "https://example.com/docs/payments"
+    }
+  ]
+}
+```
+````
+
+### 5.4 Security and privacy
+
+Structured-data hints **MUST NOT** include secrets, access tokens, non-public personally identifiable information (PII), user-specific data, private pricing, non-public roadmap details, or content not intended for public AI retrieval.
+
+If a markdown twin is served dynamically in an authenticated context, publishers **MUST** sanitize or omit user-specific PII from both the visible markdown and structured-data hints before serving the response to AI agents. Direct identifiers such as email addresses, phone numbers, physical addresses, and financial details **SHOULD NOT** appear in structured-data hints unless they also appear in the visible page content and are intended to be publicly discoverable.
+
+Publishers **SHOULD** treat structured-data hints as public content equivalent to the visible markdown twin.
+
+## 6. Migration Notes
+
+Sites implementing AEO Spec v1.0 can adopt this draft incrementally:
+
+1. Continue serving existing markdown twins and headers unchanged.
+2. Add stable explicit anchors to high-value FAQ, pricing, docs, and policy sections.
+3. Publish `/sitemap.md` once markdown twin metadata is available.
+4. Add structured-data hints only where the visible markdown already contains the same facts.
+5. Update `X-AEO-Version` only when the implementation intentionally targets a finalized v1.1 conformance profile.
+
+Draft implementors who want to signal partial adoption before finalization **MAY** use non-conformance feature signaling such as `X-AEO-Draft: 1.1` or `X-AEO-Features: sitemap-md, section-anchors, aeo-schema`. Clients **MUST NOT** treat these draft signals as proof of finalized v1.1 conformance.
+
+Servers **MAY** include a `variant` parameter when they know the markdown dialect they emit, for example `text/markdown; charset=utf-8; variant=GFM`. Clients **MUST NOT** rely on this parameter being present.
+
+This draft does not require a changeset or runtime package release by itself. Package-specific implementation work should be tracked in follow-up issues or pull requests.
+
+## 7. Open Questions
+
+The following questions should be resolved before finalizing AEO Spec v1.1. Implementors targeting this draft **SHOULD** treat the examples and current leanings below as tentative behavior until the spec is finalized.
+
+1. Should `/sitemap.md` define a minimal flat profile for clients and treat grouped sections as a presentational superset? Current leaning: yes; entries are parsed per bullet regardless of heading nesting.
+2. Should `tokens` remain optional because token estimation can be model-specific or expensive? Current leaning: yes; missing values mean unknown, not `0`, and clients can fetch the page or skip token-budget routing.
+3. Should the spec define `aeo-schema` as the canonical language identifier while explicitly allowing `jsonld`, `json-ld`, and `application/ld+json` as aliases when the block shape is JSON-LD? Current leaning: yes.
+4. When both explicit HTML anchors and a slug algorithm are available, which identifier takes precedence, and should clients also recognize CommonMark attribute IDs where present? Current leaning: explicit anchors take precedence; attribute IDs are optional compatibility syntax.
+5. Should AEO servers be encouraged to include a `variant` parameter when they know the markdown dialect, while clients **MUST NOT** rely on its presence? Current leaning: yes.
+6. If very large sites publish shard files such as `/sitemap-docs.md` and `/sitemap-blog.md`, should `/sitemap.md` be the discoverable index that links to all shards, and should there be recommended size limits per shard? Current leaning: yes for an index; size limits need field testing.
+7. Should canonical markdown twin metadata grow a first-class `canonical` key, or is the existing rule of one canonical markdown twin per canonical HTML URL enough for v1.1?
+
+## 8. References
+
+- [AEO Specification v1.0](./README.md)
+- [AEO Spec — Discovery](./discovery.md)
+- [AEO Spec — Headers Contract](./headers.md)
+- [AEO Spec — Conformance](./conformance.md)
+- [AEO Spec — llms.txt Extensions](./llms-txt-extensions.md)
+- [RFC 2119: Key words for use in RFCs to Indicate Requirement Levels](https://www.rfc-editor.org/rfc/rfc2119)
+- [RFC 7763: The text/markdown Media Type](https://www.rfc-editor.org/rfc/rfc7763)
+- [RFC 7764: Guidance on Markdown Design Philosophies, Stability Strategies, and Select Registrations](https://www.rfc-editor.org/rfc/rfc7764)
+- [RFC 8288: Web Linking](https://www.rfc-editor.org/rfc/rfc8288)
+- [schema.org](https://schema.org/)
+- [llms.txt proposal](https://llmstxt.org/)


### PR DESCRIPTION
## Summary

Adds the first draft of AEO Spec v1.1 in `spec/v1.1-draft.md`.

This draft proposes three additive extensions:

- `/sitemap.md` for markdown twin discovery
- stable section anchors for deep links into markdown twins
- structured-data hints via fenced markdown blocks

## Scope

This is spec only. It does not change packages, adapters, examples, CLI checks, conformance scoring, or runtime behavior.

## Compatibility

AEO v1.0 conformance remains valid. The v1.1 features are additive and can be adopted independently.

## Discussion

GitHub Discussions are not enabled for this repository, so please use this PR thread for design feedback before merge. General feedback can go in the PR conversation, and detailed feedback can use inline comments on `spec/v1.1-draft.md`.

The draft calls out open questions around:

- flat versus grouped `/sitemap.md`
- optional token counts
- `aeo-schema` aliases
- explicit anchors versus fallback slugs
- markdown `variant` signaling
- sitemap shards
- canonical markdown twin metadata

## Verification

- `bunx prettier --check spec/v1.1-draft.md`
- `git diff --check`

Refs #18
