### PR TITLE
fix: always set Vary: Accept on HTML even when the Link header is disabled

### DIFF
--- a/.changeset/vary-accept-independent-of-link-header.md
+++ b/.changeset/vary-accept-independent-of-link-header.md
@@ -1,0 +1,13 @@
+---
+"@dualmark/cloudflare": patch
+"@dualmark/netlify": patch
+"@dualmark/vercel": patch
+"@dualmark/nextjs": patch
+"@dualmark/sveltekit": patch
+---
+
+Always set `Vary: Accept` on negotiable HTML responses, even when the Link header is disabled.
+
+Several adapters tied the `Vary: Accept` header to the Link-header feature flag, so configuring `enableLinkHeader: false` (or `injectLinkHeader: false`) left the HTML response with no `Vary` header. A shared cache keyed only on the URL could then serve an HTML response to a client that asked for markdown, or the reverse.
+
+The spec (content-negotiation.md section 3) requires `Vary: Accept` on every response whose representation depends on the `Accept` header, which is independent of whether the markdown twin is advertised via a Link header. The cloudflare, netlify, vercel, nextjs and sveltekit adapters now always emit `Vary: Accept` on negotiable HTML and only gate the `Link` header on the flag, matching the deno and fastly adapters which already did this.

--- a/packages/cloudflare/src/worker.ts
+++ b/packages/cloudflare/src/worker.ts
@@ -276,21 +276,22 @@ export function createAEOWorker<Env extends MinimalEnv = MinimalEnv>(
       const upstreamResponse = await options.upstream.fetch(request, env, ctx);
 
       if (
-        enableLinkHeader &&
         !shouldSkip(pathname, skipPrefixes, skipExtensions) &&
         !pathname.endsWith(".md") &&
         upstreamResponse.headers.get("content-type")?.includes("text/html")
       ) {
-        const mdPath = toMarkdownPath(pathname);
         const newHeaders = new Headers(upstreamResponse.headers);
-        const link = `<${mdPath}>; rel="alternate"; type="text/markdown"`;
-        const existing = newHeaders.get("Link");
-        newHeaders.set("Link", existing ? `${existing}, ${link}` : link);
         const vary = newHeaders.get("Vary");
         if (!vary) {
           newHeaders.set("Vary", "Accept");
         } else if (!vary.split(",").map((s) => s.trim().toLowerCase()).includes("accept")) {
           newHeaders.set("Vary", `${vary}, Accept`);
+        }
+        if (enableLinkHeader) {
+          const mdPath = toMarkdownPath(pathname);
+          const link = `<${mdPath}>; rel="alternate"; type="text/markdown"`;
+          const existing = newHeaders.get("Link");
+          newHeaders.set("Link", existing ? `${existing}, ${link}` : link);
         }
         return new Response(upstreamResponse.body, {
           status: upstreamResponse.status,

--- a/packages/cloudflare/test/worker.test.ts
+++ b/packages/cloudflare/test/worker.test.ts
@@ -431,4 +431,23 @@ describe("createAEOWorker — Link header injection", () => {
     const res = await worker.fetch(new Request("https://acme.test/page"), env, makeCtx());
     expect(res.headers.get("link")).toBeNull();
   });
+
+  it("sets Vary: Accept on HTML even when the Link header is disabled", async () => {
+    const env: TestEnv = { ASSETS: makeAssets({}) };
+    const worker = createAEOWorker({
+      upstream: makeUpstream(
+        () => new Response("<html></html>", { headers: { "Content-Type": "text/html" } }),
+      ),
+      enableLinkHeader: false,
+    });
+    const req = new Request("https://acme.test/page", {
+      headers: {
+        "user-agent": "Mozilla/5.0 Chrome/130",
+        accept: "text/html,*/*;q=0.8",
+      },
+    });
+    const res = await worker.fetch(req, env, makeCtx());
+    expect((res.headers.get("vary") ?? "").toLowerCase()).toContain("accept");
+    expect(res.headers.get("link")).toBeNull();
+  });
 });

--- a/packages/netlify/src/worker.ts
+++ b/packages/netlify/src/worker.ts
@@ -261,21 +261,22 @@ export function createAEOWorker(
     const originResponse = await context.next();
 
     if (
-      enableLinkHeader &&
       !shouldSkip(pathname, skipPrefixes, skipExtensions) &&
       !pathname.endsWith(".md") &&
       originResponse.headers.get("content-type")?.includes("text/html")
     ) {
-      const mdPath = toMarkdownPath(pathname);
       const newHeaders = new Headers(originResponse.headers);
-      const link = `<${mdPath}>; rel="alternate"; type="text/markdown"`;
-      const existing = newHeaders.get("Link");
-      newHeaders.set("Link", existing ? `${existing}, ${link}` : link);
       const vary = newHeaders.get("Vary");
       if (!vary) {
         newHeaders.set("Vary", "Accept");
       } else if (!vary.split(",").map((s) => s.trim().toLowerCase()).includes("accept")) {
         newHeaders.set("Vary", `${vary}, Accept`);
+      }
+      if (enableLinkHeader) {
+        const mdPath = toMarkdownPath(pathname);
+        const link = `<${mdPath}>; rel="alternate"; type="text/markdown"`;
+        const existing = newHeaders.get("Link");
+        newHeaders.set("Link", existing ? `${existing}, ${link}` : link);
       }
       return new Response(originResponse.body, {
         status: originResponse.status,

--- a/packages/netlify/test/worker.test.ts
+++ b/packages/netlify/test/worker.test.ts
@@ -380,6 +380,25 @@ describe("createAEOWorker — Link header injection", () => {
     expect(res.headers.get("link")).toBeNull();
   });
 
+  it("sets Vary: Accept on HTML even when the Link header is disabled", async () => {
+    const assets = makeAssets({});
+    const worker = createAEOWorker({ assets, enableLinkHeader: false });
+    const req = new Request("https://acme.test/page", {
+      headers: {
+        "user-agent": "Mozilla/5.0 Chrome/130",
+        accept: "text/html,*/*;q=0.8",
+      },
+    });
+    const res = await worker(
+      req,
+      makeContext(
+        () => new Response("<html></html>", { headers: { "Content-Type": "text/html" } }),
+      ),
+    );
+    expect((res.headers.get("vary") ?? "").toLowerCase()).toContain("accept");
+    expect(res.headers.get("link")).toBeNull();
+  });
+
   it("appends Accept to existing Vary header", async () => {
     const assets = makeAssets({});
     const worker = createAEOWorker({ assets });

--- a/packages/nextjs/src/middleware.ts
+++ b/packages/nextjs/src/middleware.ts
@@ -139,12 +139,14 @@ export function handleRequest(
   }
 
   const res = NextResponse.next();
+  // Vary: Accept is always required on a negotiable page; the Link header is
+  // opt-out via injectLinkHeader.
+  appendVaryAccept(res.headers);
   if (resolved.middleware.injectLinkHeader) {
     const mdPath = toMarkdownPath(pathname);
     const link = `<${mdPath}>; rel="alternate"; type="text/markdown"`;
     const existing = res.headers.get("Link");
     res.headers.set("Link", existing ? `${existing}, ${link}` : link);
-    appendVaryAccept(res.headers);
   }
   return res;
 }

--- a/packages/nextjs/test/middleware.test.ts
+++ b/packages/nextjs/test/middleware.test.ts
@@ -124,6 +124,20 @@ describe("handleRequest — bot/Accept negotiation", () => {
     const res = handleRequest(req, FakeNextResponse, r);
     expect(res.headers.get("link")).toBeNull();
   });
+
+  it("sets Vary: Accept on HTML even when the Link header is disabled", () => {
+    const r = resolveConfig({
+      siteUrl: "https://example.com",
+      middleware: { injectLinkHeader: false },
+    });
+    const req = makeReq("https://example.com/blog/hello", {
+      "user-agent": "Mozilla/5.0 Chrome/130",
+      accept: "text/html,*/*;q=0.8",
+    });
+    const res = handleRequest(req, FakeNextResponse, r);
+    expect((res.headers.get("vary") ?? "").toLowerCase()).toContain("accept");
+    expect(res.headers.get("link")).toBeNull();
+  });
 });
 
 describe("handleRequest — skip rules", () => {

--- a/packages/sveltekit/src/handle.ts
+++ b/packages/sveltekit/src/handle.ts
@@ -78,13 +78,29 @@ export async function handleRequest(
   }
 
   const response = await resolve(event);
-  if (!resolved.middleware.injectLinkHeader) return response;
   if (pathname.endsWith(".md")) return response;
 
   const contentType = response.headers.get("content-type") ?? "";
   if (!contentType.toLowerCase().includes("text/html")) return response;
 
-  return injectMarkdownAlternateLink(response, pathname, toMarkdownPath(pathname));
+  if (resolved.middleware.injectLinkHeader) {
+    return injectMarkdownAlternateLink(response, pathname, toMarkdownPath(pathname));
+  }
+
+  // Even with the Link header disabled, a negotiable HTML page MUST advertise
+  // Vary: Accept so a shared cache does not serve it to a markdown client.
+  const headers = new Headers(response.headers);
+  const vary = headers.get("Vary");
+  if (!vary) {
+    headers.set("Vary", "Accept");
+  } else if (!vary.split(",").map((s) => s.trim().toLowerCase()).includes("accept")) {
+    headers.set("Vary", `${vary}, Accept`);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }
 
 export function createDualmarkHandle(input: DualmarkSvelteKitConfig): DualmarkHandle {

--- a/packages/sveltekit/test/handle.test.ts
+++ b/packages/sveltekit/test/handle.test.ts
@@ -112,6 +112,25 @@ describe("handleRequest", () => {
       '</posts/hello.md>; rel="alternate"; type="text/markdown"',
     );
   });
+
+  it("sets Vary: Accept on HTML even when the Link header is disabled", async () => {
+    const r = resolveConfig({
+      siteUrl: "https://example.com",
+      middleware: { injectLinkHeader: false },
+    });
+    const response = await handleRequest(
+      makeEvent("https://example.com/posts/hello", {
+        "user-agent": "Mozilla/5.0 Chrome/130",
+        accept: "text/html,*/*;q=0.8",
+      }),
+      async () =>
+        new Response("<html></html>", { headers: { "Content-Type": "text/html" } }),
+      r,
+    );
+
+    expect((response.headers.get("vary") ?? "").toLowerCase()).toContain("accept");
+    expect(response.headers.get("link")).toBeNull();
+  });
 });
 
 describe("createDualmarkHandle", () => {

--- a/packages/vercel/src/middleware.ts
+++ b/packages/vercel/src/middleware.ts
@@ -286,11 +286,7 @@ export function createAEOMiddleware(
 
     const upstreamResponse = await options.upstream(request);
 
-    if (
-      enableLinkHeader &&
-      !shouldSkip(pathname, skipPrefixes, skipExtensions) &&
-      !pathname.endsWith(".md")
-    ) {
+    if (!shouldSkip(pathname, skipPrefixes, skipExtensions) && !pathname.endsWith(".md")) {
       const ct = upstreamResponse.headers.get("content-type");
       // Passthrough responses (e.g. NextResponse.next()) have no content-type yet —
       // always inject. For concrete responses, only inject on text/html.
@@ -298,14 +294,15 @@ export function createAEOMiddleware(
         const mdPath = toMarkdownPath(pathname);
         try {
           // Fast path: mutate headers in-place (works for NextResponse.next() and
-          // freshly constructed Response objects).
-          appendLinkHeader(upstreamResponse.headers, mdPath);
+          // freshly constructed Response objects). Vary: Accept is always required
+          // on a negotiable page; the Link header is opt-out via enableLinkHeader.
           appendVaryAccept(upstreamResponse.headers);
+          if (enableLinkHeader) appendLinkHeader(upstreamResponse.headers, mdPath);
         } catch {
           // Immutable headers (e.g. from fetch()) — clone into new Response.
           const newHeaders = new Headers(upstreamResponse.headers);
-          appendLinkHeader(newHeaders, mdPath);
           appendVaryAccept(newHeaders);
+          if (enableLinkHeader) appendLinkHeader(newHeaders, mdPath);
           return new Response(upstreamResponse.body, {
             status: upstreamResponse.status,
             statusText: upstreamResponse.statusText,

--- a/packages/vercel/test/middleware.test.ts
+++ b/packages/vercel/test/middleware.test.ts
@@ -392,6 +392,26 @@ describe("createAEOMiddleware — Link header injection", () => {
     const res = await middleware(new Request("https://acme.test/page"), makeCtx());
     expect(res.headers.get("link")).toBeNull();
   });
+
+  it("sets Vary: Accept on HTML even when the Link header is disabled", async () => {
+    const htmlResponse = new Response("<html></html>", {
+      headers: { "Content-Type": "text/html" },
+    });
+    const middleware = createAEOMiddleware({
+      upstream: makeUpstream(() => htmlResponse),
+      fetchAsset,
+      enableLinkHeader: false,
+    });
+    const req = new Request("https://acme.test/page", {
+      headers: {
+        "user-agent": "Mozilla/5.0 Chrome/130",
+        accept: "text/html,*/*;q=0.8",
+      },
+    });
+    const res = await middleware(req, makeCtx());
+    expect((res.headers.get("vary") ?? "").toLowerCase()).toContain("accept");
+    expect(res.headers.get("link")).toBeNull();
+  });
 });
 
 describe("createAEOMiddleware — edge cases", () => {


### PR DESCRIPTION
## Summary

Turning off the Link header (`enableLinkHeader: false`, or `injectLinkHeader: false` on nextjs/sveltekit) also dropped `Vary: Accept` from negotiable HTML responses, because the Vary logic was nested inside the Link-header block. That is a cache-correctness bug: a shared cache keyed on the URL can then serve HTML to a markdown client or the reverse. This decouples the two so Vary is always set.

Closes #72.

## Changes

- cloudflare, netlify, vercel, nextjs and sveltekit now always set `Vary: Accept` on a negotiable HTML response, and gate only the `Link` header on the feature flag. This matches the deno and fastly adapters, which already did it this way.
- Added a regression test in each of the five adapters: with the Link header disabled, a browser request to an HTML page still gets `Vary: Accept` and no `Link` header.

## Type

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Spec change (requires bump in `AEO_SPEC_VERSION`)
- [ ] Docs / examples / tooling only

## Verification

- [x] `bun run build` passes
- [x] `bun run test` passes
- [x] `bun run typecheck` passes
- [ ] If touching examples: ran `dualmark verify` (no examples touched)
- [ ] If touching `/spec/`: ran sync-spec (no spec files touched)

## Changeset

- [x] Added a changeset (patch for the five adapters)

---

cc @thepushkaraj @aagarwal1012. This follows the same pattern deno/fastly already use, so it should be low risk, but happy to adjust if you would rather I factor the shared Vary-append into a small core helper.
