### PR TITLE
fix(converters): stop blog footer turning the last body line into a heading

### DIFF
--- a/.changeset/blog-converter-setext-heading.md
+++ b/.changeset/blog-converter-setext-heading.md
@@ -1,0 +1,7 @@
+---
+"@dualmark/converters": patch
+---
+
+Fix the blog converter turning a post's last body line into a heading.
+
+The footer was concatenated directly onto the body with no blank line, so the output ended with `last body line\n---`. CommonMark parses a line of text immediately followed by `---` as a setext H2, which turned the final line of every blog post body into a heading and dropped the intended horizontal rule before the footer links. The body and footer are now separated by a blank line so the `---` is a thematic break.

--- a/packages/converters/src/blog.ts
+++ b/packages/converters/src/blog.ts
@@ -52,6 +52,10 @@ export function blogConverter(
       footer.push(`- [All articles](${config.siteUrl}${basePath})`);
     }
     if (config.brandFooter) footer.push("", config.brandFooter);
-    return normalizeUnicode(base + footer.join("\n"));
+    // Separate the body from the footer with a blank line. `base` ends with the
+    // body's last line (no trailing newline) and `footer` starts with "---";
+    // without the blank line CommonMark parses "lastline\n---" as a setext H2,
+    // turning the final body line into a heading and swallowing the rule.
+    return normalizeUnicode(base + "\n" + footer.join("\n"));
   };
 }

--- a/packages/converters/test/converters.test.ts
+++ b/packages/converters/test/converters.test.ts
@@ -78,6 +78,18 @@ describe("blogConverter", () => {
     });
     expect(out).toContain("## About Acme");
   });
+
+  it("separates the body from the footer so the last line is not a setext heading", () => {
+    const out = convert({
+      id: "p",
+      data: { title: "T", publishedDate: new Date("2026-01-01T00:00:00Z") },
+      body: "Final body line.",
+    });
+    // "Final body line.\n---" would render as a setext H2 in CommonMark,
+    // turning the last body line into a heading and dropping the rule.
+    expect(out).toContain("Final body line.\n\n---");
+    expect(out).not.toContain("Final body line.\n---\n");
+  });
 });
 
 describe("caseStudyConverter", () => {


### PR DESCRIPTION
## Summary

The blog converter joined its footer onto the body with no blank line, so the output ended with `last body line\n---`. CommonMark reads that as a setext H2, so the final line of every blog post body was rendered as a heading and the horizontal rule before the footer links vanished. This adds the missing blank line.

Closes #74.

## Changes

- `packages/converters/src/blog.ts`: separate the body from the footer with a blank line so the trailing `---` is a thematic break, not a setext underline.
- Added a regression test asserting the last body line is followed by a blank line and `---`, and is not glued directly to `---`.

## Type

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Spec change (requires bump in `AEO_SPEC_VERSION`)
- [ ] Docs / examples / tooling only

## Verification

- [x] `bun run build` passes
- [x] `bun run test` passes (converters: 39 tests)
- [x] `bun run typecheck` passes
- [ ] If touching examples: ran `dualmark verify` (no examples touched)
- [ ] If touching `/spec/`: ran sync-spec (no spec files touched)

## Changeset

- [x] Added a changeset (patch for `@dualmark/converters`)

---

cc @thepushkaraj @aagarwal1012. Small one, but it affects the rendered markdown of every blog post that has a body.
