### PR TITLE
fix(core): convert multi-line tags in cleanBody

### DIFF
--- a/.changeset/cleanbody-multiline-tags.md
+++ b/.changeset/cleanbody-multiline-tags.md
@@ -1,0 +1,7 @@
+---
+"@dualmark/core": patch
+---
+
+Fix `cleanBody` leaking raw tags when a tag spans multiple lines.
+
+The HTML-tag replacement (e.g. `<Highlighted>…</Highlighted>` to `**…**`, and any custom `htmlTagReplacements`) used a regex without the dotAll flag, so `.` never matched newlines. A tag whose content spanned more than one line was left untouched, leaking raw markup into the cleaned markdown that AI clients read. The regex now uses the `s` flag while keeping the lazy match, so multi-line tags are converted and adjacent tags are not merged.

--- a/packages/core/src/text.ts
+++ b/packages/core/src/text.ts
@@ -70,7 +70,11 @@ export function cleanBody(body: string, opts: CleanBodyOptions = {}): string {
   let out = stripImg ? stripImages(body) : body;
 
   for (const [tag, marker] of Object.entries(replacements)) {
-    const re = new RegExp(`<${tag}>(.*?)<\\/${tag}>`, "g");
+    // `s` (dotAll) so a tag whose content spans multiple lines is still
+    // replaced; without it a multi-line `<Tag>…</Tag>` leaks its raw markup
+    // into the cleaned markdown. `.*?` stays lazy, so it still stops at the
+    // first closing tag.
+    const re = new RegExp(`<${tag}>(.*?)<\\/${tag}>`, "gs");
     out = out.replace(re, `${marker}$1${marker}`);
   }
 

--- a/packages/core/test/text.test.ts
+++ b/packages/core/test/text.test.ts
@@ -86,6 +86,18 @@ describe("cleanBody", () => {
     expect(cleanBody("see <Highlighted>this</Highlighted>")).toBe("see **this**");
   });
 
+  it("converts a tag whose content spans multiple lines", () => {
+    expect(cleanBody("see <Highlighted>multi\nline</Highlighted> end")).toBe(
+      "see **multi\nline** end",
+    );
+  });
+
+  it("keeps tag replacement lazy across multiple tags", () => {
+    expect(cleanBody("<Em>a</Em> mid <Em>b</Em>", { htmlTagReplacements: { Em: "*" } })).toBe(
+      "*a* mid *b*",
+    );
+  });
+
   it("converts <br> to newline", () => {
     expect(cleanBody("line1<br>line2<br/>line3")).toBe("line1\nline2\nline3");
   });


### PR DESCRIPTION
## Summary

`cleanBody` replaced configured tags with a regex missing the dotAll flag, so a `<Tag>…</Tag>` whose content spanned multiple lines was left in the output as raw markup. This adds the `s` flag so multi-line tags are converted too.

Closes #76.

## Changes

- `packages/core/src/text.ts`: add the `s` (dotAll) flag to the tag-replacement regex. The match stays lazy (`.*?`), so it still stops at the first closing tag and does not merge two adjacent tags.
- Added two tests: a multi-line tag is converted, and adjacent tags are not merged.

## Type

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Spec change (requires bump in `AEO_SPEC_VERSION`)
- [ ] Docs / examples / tooling only

## Verification

- [x] `bun run build` passes
- [x] `bun run test` passes (core: 182 tests)
- [x] `bun run typecheck` passes
- [ ] If touching examples: ran `dualmark verify` (no examples touched)
- [ ] If touching `/spec/`: ran sync-spec (no spec files touched)

## Changeset

- [x] Added a changeset (patch for `@dualmark/core`)

---

cc @thepushkaraj @aagarwal1012. Small core fix, keeps the existing single-line behavior identical.
