### PR TITLE
fix(core): strip trailing slash before .md check in toMarkdownPath

### DIFF
--- a/.changeset/tomarkdownpath-trailing-slash.md
+++ b/.changeset/tomarkdownpath-trailing-slash.md
@@ -1,0 +1,7 @@
+---
+"@dualmark/core": patch
+---
+
+Fix `toMarkdownPath` doubling the extension on a `.md` path with a trailing slash.
+
+The `.md` idempotency check ran before trailing slashes were stripped, so `toMarkdownPath("/blog/post.md/")` returned `/blog/post.md.md` (and `toMarkdownUrl` produced the same doubled path), which would 404. Trailing slashes are now stripped first, so a markdown path with a trailing slash maps back to itself. All other cases (root to `/index.md`, trailing-slash stripping, deep nesting) are unchanged.

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -18,9 +18,12 @@
  *   "/blog/x.md"  → "/blog/x.md"   (idempotent)
  */
 export function toMarkdownPath(pathname: string): string {
-  if (pathname.endsWith(".md")) return pathname;
+  // Strip trailing slashes before the `.md` check, otherwise a markdown path
+  // with a trailing slash (e.g. "/blog/post.md/") defeats the idempotency
+  // guard and gets a doubled extension ("/blog/post.md.md").
   const trimmed = pathname.replace(/\/+$/, "");
   if (trimmed === "") return "/index.md";
+  if (trimmed.endsWith(".md")) return trimmed;
   return trimmed + ".md";
 }
 

--- a/packages/core/test/paths.test.ts
+++ b/packages/core/test/paths.test.ts
@@ -24,6 +24,11 @@ describe("toMarkdownPath", () => {
     expect(toMarkdownPath("/index.md")).toBe("/index.md");
   });
 
+  it("does not double the extension for a .md path with a trailing slash", () => {
+    expect(toMarkdownPath("/a.md/")).toBe("/a.md");
+    expect(toMarkdownPath("/blog/post.md/")).toBe("/blog/post.md");
+  });
+
   it("handles deep nesting", () => {
     expect(toMarkdownPath("/a/b/c/d/e")).toBe("/a/b/c/d/e.md");
   });


### PR DESCRIPTION
## Summary

`toMarkdownPath` ran its `.md` idempotency check before stripping trailing slashes, so a markdown path with a trailing slash (e.g. `/blog/post.md/`) came out as `/blog/post.md.md` and would 404. This strips trailing slashes first.

Closes #78.

## Changes

- `packages/core/src/paths.ts`: strip trailing slashes before the `.md` check, so an already-`.md` path maps back to itself with or without a trailing slash. This also fixes `toMarkdownUrl`, which delegates to `toMarkdownPath`.
- Added a regression test for `/a.md/` and `/blog/post.md/`.

Other cases (root to `/index.md`, trailing-slash stripping, deep nesting, query/hash preservation) are unchanged.

## Type

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Spec change (requires bump in `AEO_SPEC_VERSION`)
- [ ] Docs / examples / tooling only

## Verification

- [x] `bun run build` passes
- [x] `bun run test` passes (core: 181 tests)
- [x] `bun run typecheck` passes
- [ ] If touching examples: ran `dualmark verify` (no examples touched)
- [ ] If touching `/spec/`: ran sync-spec (no spec files touched)

## Changeset

- [x] Added a changeset (patch for `@dualmark/core`)

---

cc @thepushkaraj @aagarwal1012.

