### PR TITLE
fix(nuxt): set Vary and Content-Type on the 406 response

### DIFF
--- a/.changeset/nuxt-406-headers.md
+++ b/.changeset/nuxt-406-headers.md
@@ -1,0 +1,7 @@
+---
+"@dualmark/nuxt": patch
+---
+
+Set the required headers on the Nuxt 406 response.
+
+When a request explicitly excluded both `text/html` and `text/markdown`, the Nuxt adapter returned `new Response('Not Acceptable', { status: 406 })` with no headers. The spec (content-negotiation.md section 4) requires a 406 to set `Vary: Accept`, and it should carry a `Content-Type` and a body listing the supported types. The 406 now matches the other adapters: `Content-Type: text/plain; charset=utf-8`, `Vary: Accept`, and a supported-types body. This applies to both the generated collection middleware and the runtime middleware.

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -281,7 +281,13 @@ export default defineEventHandler(async (event) => {
 
   // 406: client's Accept explicitly excludes both text/html and text/markdown
   if (!isMd && format === null && !botInfo.isBot) {
-    return new Response('Not Acceptable', { status: 406 });
+    return new Response('Not Acceptable\\n\\nSupported types: text/html, text/markdown\\n', {
+      status: 406,
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        Vary: 'Accept',
+      },
+    });
   }
 
   const serveMarkdown = isMd || botInfo.isBot || format === 'markdown';

--- a/packages/nuxt/src/runtime/server/endpoints/middleware.ts
+++ b/packages/nuxt/src/runtime/server/endpoints/middleware.ts
@@ -35,7 +35,13 @@ export function makeCollectionMiddleware<TEntry = CollectionEntry<unknown>>(
     const format = negotiateFormat(accept);
 
     if (!isMd && format === null && !botInfo.isBot) {
-      return new Response('Not Acceptable', { status: 406 });
+      return new Response('Not Acceptable\n\nSupported types: text/html, text/markdown\n', {
+        status: 406,
+        headers: {
+          'Content-Type': 'text/plain; charset=utf-8',
+          Vary: 'Accept',
+        },
+      });
     }
 
     const serveMarkdown = isMd || botInfo.isBot || format === 'markdown';

--- a/packages/nuxt/test/middleware.test.ts
+++ b/packages/nuxt/test/middleware.test.ts
@@ -54,6 +54,9 @@ describe('makeCollectionMiddleware content negotiation', () => {
     const res = await handler(event) as Response;
     expect(res).toBeInstanceOf(Response);
     expect(res.status).toBe(406);
+    // Spec section 4: a 406 MUST set Vary: Accept and should be typed text/plain.
+    expect((res.headers.get('vary') ?? '').toLowerCase()).toContain('accept');
+    expect(res.headers.get('content-type')).toContain('text/plain');
   });
 
   it('serves markdown if .md extension is used', async () => {


### PR DESCRIPTION
## Summary

The Nuxt adapter returned a bare `Not Acceptable` 406 with no headers, so it was missing the spec-required `Vary: Accept` (and had no `Content-Type` or supported-types body). This matches it to the other adapters.

Closes #80.

## Changes

- `packages/nuxt/src/runtime/server/endpoints/middleware.ts` and the `getMiddlewareCode` template in `packages/nuxt/src/module.ts`: the 406 now returns `Content-Type: text/plain; charset=utf-8`, `Vary: Accept`, and a body listing the supported types.
- Extended the existing Nuxt 406 test to assert `Vary` contains `Accept` and the `Content-Type` is `text/plain`.

## Type

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Spec change (requires bump in `AEO_SPEC_VERSION`)
- [ ] Docs / examples / tooling only

## Verification

- [x] `bun run build` passes
- [x] `bun run test` passes (nuxt: 49 tests)
- [x] `bun run typecheck` passes
- [ ] If touching examples: ran `dualmark verify` (no examples touched)
- [ ] If touching `/spec/`: ran sync-spec (no spec files touched)

## Changeset

- [x] Added a changeset (patch for `@dualmark/nuxt`)

---

cc @thepushkaraj @aagarwal1012.
