### PR TITLE
ci(release): npm Trusted Publishing (OIDC), drop NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,13 @@ jobs:
         with:
           registry-url: https://registry.npmjs.org
 
+      # npm Trusted Publishing (OIDC) requires npm >= 11.5.1, but Node 22
+      # ships npm 10.x. Pin an explicit version rather than @latest because
+      # `npm install -g npm@latest` has hit broken self-upgrade chains
+      # (missing transitive deps like promise-retry).
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11.5.1
+
       # Refresh bun.lock workspace metadata so `bun pm pack` (later step)
       # rewrites `workspace:*` deps in the tarball to the tag's actual
       # versions. `bun install --frozen-lockfile` (in setup) does NOT update
@@ -107,8 +114,13 @@ jobs:
         #   is cryptographically tied to this exact workflow file + commit SHA.
         #   Permission is granted at the job level above.
         #
-        # Auth: `actions/setup-node` (in our setup composite action) writes
-        # ~/.npmrc to read $NODE_AUTH_TOKEN, which is what `npm publish` uses.
+        # Auth: npm Trusted Publishing (OIDC) — no NPM_TOKEN. The same
+        # `id-token: write` OIDC identity that signs provenance also
+        # authenticates the publish, so `npm publish` needs no NODE_AUTH_TOKEN.
+        # Each @dualmark/* package must have this repo + this workflow file
+        # (release.yml) registered as a trusted publisher on npmjs.com. With
+        # OIDC, `--provenance` is implied and can be omitted, but we keep it
+        # explicit for clarity.
         run: |
           set -euo pipefail
           published_count=0
@@ -147,5 +159,3 @@ jobs:
           done
           echo ""
           echo "Published $published_count package(s) to npm with provenance attestation."
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,11 +48,13 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       # npm Trusted Publishing (OIDC) requires npm >= 11.5.1, but Node 22
-      # ships npm 10.x. Pin an explicit version rather than @latest because
-      # `npm install -g npm@latest` has hit broken self-upgrade chains
-      # (missing transitive deps like promise-retry).
+      # ships npm 10.x. We pin 11.6.2 rather than the 11.5.1 floor: 11.5.2
+      # fixed an OIDC/provenance ordering bug (npm/cli#8467) and 11.6.2 is the
+      # version reported to actually resolve trusted-publishing failures in the
+      # wild (npm/cli#9088). Pin (not @latest) for reproducible release runs;
+      # bump this deliberately.
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@11.5.1
+        run: npm install -g npm@11.6.2
 
       # Refresh bun.lock workspace metadata so `bun pm pack` (later step)
       # rewrites `workspace:*` deps in the tarball to the tag's actual
@@ -118,23 +120,64 @@ jobs:
         # `id-token: write` OIDC identity that signs provenance also
         # authenticates the publish, so `npm publish` needs no NODE_AUTH_TOKEN.
         # Each @dualmark/* package must have this repo + this workflow file
-        # (release.yml) registered as a trusted publisher on npmjs.com. With
-        # OIDC, `--provenance` is implied and can be omitted, but we keep it
-        # explicit for clarity.
+        # (release.yml) registered as a trusted publisher on npmjs.com.
+        # `--provenance` is kept explicit: npm's OIDC auto-enable path only
+        # fires when `provenance` is at its default config state, so passing
+        # the flag guarantees provenance rather than relying on that branch.
+        #
+        # NODE_AUTH_TOKEN is unset here on purpose. `actions/setup-node`
+        # (in the setup composite) writes an npmrc and exports NODE_AUTH_TOKEN
+        # defaulted to a literal placeholder ("XXXXX-...") when no real token
+        # is supplied. That placeholder is a syntactically valid credential,
+        # so if the OIDC exchange fails (`oidc()` is designed to never throw),
+        # npm would skip its ENEEDAUTH fail-fast and PUT with the dummy token —
+        # surfacing a trusted-publisher misconfig as an opaque 404 instead of
+        # an auth error (npm/cli#9088). Clearing it forces a loud, correct
+        # failure. `--loglevel verbose` makes the `oidc` log lines visible.
+        env:
+          NODE_AUTH_TOKEN: ""
         run: |
-          set -euo pipefail
-          published_count=0
+          set -uo pipefail
+
+          # Pre-flight: build the list of packages that still need publishing,
+          # so a bad state is visible before the first PUT rather than halfway
+          # through. `npm view` runs unauthenticated against the public
+          # registry (the idempotent-skip signal).
+          to_publish=()
+          echo "::group::Pre-flight — packages pending publish"
           for pkg_dir in packages/*; do
-            if [ ! -f "$pkg_dir/package.json" ]; then continue; fi
+            [ -f "$pkg_dir/package.json" ] || continue
             pkg_name=$(node -p "require('./$pkg_dir/package.json').name")
             pkg_version=$(node -p "require('./$pkg_dir/package.json').version")
             published=$(npm view "$pkg_name@$pkg_version" version --silent 2>/dev/null || true)
             if [ -n "$published" ]; then
-              echo "::group::$pkg_name@$pkg_version (skip — already on npm)"
-              echo "  registry reports version: $published"
-              echo "::endgroup::"
-              continue
+              echo "  $pkg_name@$pkg_version — already on npm, will skip"
+            else
+              echo "  $pkg_name@$pkg_version — PENDING"
+              to_publish+=("$pkg_dir")
             fi
+          done
+          echo "::endgroup::"
+
+          if [ "${#to_publish[@]}" -eq 0 ]; then
+            echo "Nothing to publish — every package version is already on npm."
+            exit 0
+          fi
+
+          # Publish each pending package. Do NOT abort the whole loop on a
+          # single failure: auth is now per-package (each needs its own
+          # trusted-publisher registration), so one misconfigured or
+          # un-bootstrapped package (e.g. a brand-new adapter that has never
+          # had a manual first publish) must not strand the rest. Re-runs are
+          # idempotent via the pre-flight skip, so continue-on-error is safe.
+          # Failures are collected and re-raised at the end so the job still
+          # goes red.
+          published_count=0
+          failed=()
+          for pkg_dir in "${to_publish[@]}"; do
+            pkg_name=$(node -p "require('./$pkg_dir/package.json').name")
+            pkg_version=$(node -p "require('./$pkg_dir/package.json').version")
+
             echo "::group::Packing $pkg_name@$pkg_version"
             # `bun pm pack --quiet` prints the tarball filename, but bun 1.3.5
             # wraps it in stray whitespace — a leading \n on Linux runners
@@ -148,14 +191,26 @@ jobs:
             tarball_abs="$(cd "$pkg_dir" && readlink -f "$tarball")"
             if [ ! -f "$tarball_abs" ]; then
               echo "::error::bun pm pack produced no tarball at expected path: $tarball_abs"
-              exit 1
+              echo "::endgroup::"
+              failed+=("$pkg_name@$pkg_version (pack)")
+              continue
             fi
             echo "  tarball: $tarball_abs"
             echo "::endgroup::"
+
             echo "::group::Publishing $pkg_name@$pkg_version (with provenance)"
-            npm publish "$tarball_abs" --access public --tag latest --provenance
+            if npm publish "$tarball_abs" --access public --tag latest --provenance --loglevel verbose; then
+              published_count=$((published_count + 1))
+            else
+              echo "::error::Failed to publish $pkg_name@$pkg_version — check the trusted-publisher registration on npmjs.com for this package (repo dodopayments/dualmark + workflow release.yml). A brand-new package needs a manual first publish before OIDC can take over."
+              failed+=("$pkg_name@$pkg_version (publish)")
+            fi
             echo "::endgroup::"
-            published_count=$((published_count + 1))
           done
+
           echo ""
           echo "Published $published_count package(s) to npm with provenance attestation."
+          if [ "${#failed[@]}" -gt 0 ]; then
+            echo "::error::${#failed[@]} package(s) failed: ${failed[*]}"
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Publishing the release fires the **`Release (npm publish)`** workflow which:
 - Publishes each tarball with `npm publish <tarball> --provenance --access public --tag latest`, which:
   - Uploads the pre-packed tarball
   - Generates a [Sigstore-backed npm provenance attestation](https://docs.npmjs.com/generating-provenance-statements) tying the published artifact to this exact workflow run + commit SHA (visible as a "Provenance" badge on the package's npm page)
-- Auth via `NODE_AUTH_TOKEN` env (wired into `~/.npmrc` by `actions/setup-node` in the composite setup action)
+- Auth via [npm Trusted Publishing (OIDC)](https://docs.npmjs.com/trusted-publishers) — no `NPM_TOKEN` secret. The workflow's `id-token: write` identity authenticates the publish, and each `@dualmark/*` package must have this repo + `release.yml` registered as a trusted publisher on npmjs.com
 - Skips packages already at that version on the registry (idempotent re-runs)
 
 Why `bun pm pack` + `npm publish` instead of just `bun publish`? As of bun 1.3.5, `bun publish` does not yet support `--provenance` (tracked at [oven-sh/bun#15601](https://github.com/oven-sh/bun/issues/15601)). When that ships in a stable bun release, the two-step flow collapses back to a single `bun publish --provenance` call.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,11 +74,20 @@ Publishing the release fires the **`Release (npm publish)`** workflow which:
   - Uploads the pre-packed tarball
   - Generates a [Sigstore-backed npm provenance attestation](https://docs.npmjs.com/generating-provenance-statements) tying the published artifact to this exact workflow run + commit SHA (visible as a "Provenance" badge on the package's npm page)
 - Auth via [npm Trusted Publishing (OIDC)](https://docs.npmjs.com/trusted-publishers) — no `NPM_TOKEN` secret. The workflow's `id-token: write` identity authenticates the publish, and each `@dualmark/*` package must have this repo + `release.yml` registered as a trusted publisher on npmjs.com
-- Skips packages already at that version on the registry (idempotent re-runs)
+- Skips packages already at that version on the registry (idempotent re-runs), and does **not** abort on a single package's failure — it publishes every package it can, then fails the job at the end listing the ones that didn't. A re-run then picks up only the stragglers.
 
 Why `bun pm pack` + `npm publish` instead of just `bun publish`? As of bun 1.3.5, `bun publish` does not yet support `--provenance` (tracked at [oven-sh/bun#15601](https://github.com/oven-sh/bun/issues/15601)). When that ships in a stable bun release, the two-step flow collapses back to a single `bun publish --provenance` call.
 
-If anything fails, the release is on GitHub but nothing is on npm — fix and re-run the workflow via **Actions → Release → Run workflow** with the tag as input.
+If some packages fail to publish, the ones that succeeded are already on npm; fix the failing packages (usually a missing trusted-publisher registration — see below) and re-run the workflow via **Actions → Release → Run workflow** with the tag as input. The re-run skips whatever already published.
+
+### Trusted-publisher rules (read before adding a package or renaming the workflow)
+
+Because publishing is OIDC-based, a few operational rules apply that are easy to trip over:
+
+- **Every new `@dualmark/*` package needs a one-time bootstrap.** npm's trusted publishing requires the package to already exist on the registry before a trusted publisher can be attached ([npm/cli#8544](https://github.com/npm/cli/issues/8544)), so CI cannot make a package's *first* publish. When you add an adapter: publish `@dualmark/<name>@<version>` once manually (a local `npm publish` with 2FA, no CI token needed), then register its trusted publisher, then let CI take over. Skipping this makes the next release fail on the new package (the rest still publish).
+- **Register the trusted publisher per package** — repo `dodopayments/dualmark`, workflow file `release.yml`. Via the npm web UI (Package → Settings → Trusted Publishers) or the CLI (`npm trust github "@dualmark/<name>" --repository dodopayments/dualmark --file release.yml --allow-publish -y`; requires npm ≥ 11.15.0 locally and account 2FA; add a short sleep between calls when looping to avoid rate limits).
+- **Do not rename `release.yml`.** The trusted publisher is bound to the *workflow filename*. Renaming or moving this file silently breaks publishing for all packages until every registration is updated to the new filename.
+- **Revoke the old `NPM_TOKEN` once OIDC is proven.** After the first successful OIDC release, delete the `NPM_TOKEN` repository secret and revoke the token on npmjs.com — leaving it in place preserves the long-lived-credential exposure this flow removed.
 
 ### Verifying provenance
 


### PR DESCRIPTION
## What

Switch the `Release (npm publish)` workflow from a long-lived `NPM_TOKEN` secret to **npm Trusted Publishing over GitHub Actions OIDC**.

The publish job already grants `id-token: write` (used for provenance). That same OIDC identity now authenticates the publish itself, so no `NODE_AUTH_TOKEN` / `secrets.NPM_TOKEN` is needed.

## Changes

- **Upgrade npm to `11.5.1`** in the release job. Node 22 ships npm 10.x, but trusted publishing requires npm >= 11.5.1. Version is pinned (not `@latest`) to avoid the known broken self-upgrade chains.
- **Drop `env: NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`** from the publish step.
- Update the workflow comment block and `CONTRIBUTING.md` to document OIDC auth.

The two-step `bun pm pack` -> `npm publish <tarball> --provenance` flow is unchanged; only the auth mechanism changes.

## Required one-time manual step (npmjs.com side — cannot be done from code)

Each `@dualmark/*` package must have a **trusted publisher** registered on npmjs.com pointing at this repo + `release.yml`, or the first OIDC publish will fail with an auth error. Do this via the npm web UI (Package -> Settings -> Trusted Publishers) **or** the npm CLI:

    # Run once per package by an npm owner/admin (requires 2FA/OTP prompt):
    for pkg in astro cli cloudflare converters core deno fastly netlify nextjs nuxt sveltekit vercel; do
      npm trust github "@dualmark/$pkg" \
        --repository dodopayments/dualmark \
        --file release.yml \
        --allow-publish -y
    done

Note: `@dualmark/fastly` is not yet published to npm, so its trusted publisher must be configured after its first publish (trusted publishing via CLI requires the package to already exist). All other 11 packages are live and can be configured now.

## Why

- Removes a long-lived, exfiltration-prone credential from CI.
- OIDC tokens are short-lived and cryptographically scoped to this exact workflow file + commit SHA.
- Aligns with the existing OIDC pattern already used in `dodopayments/quackback`.

## Verification

- YAML validated (`yaml.safe_load`).
- No `NODE_AUTH_TOKEN` / `secrets.NPM_TOKEN` references remain in the workflow.
- End-to-end publish can only be verified by cutting a release **after** the trusted publishers are registered on npmjs.com.