### PR TITLE
fix(docs): preserve anchors in synced spec links

### DIFF
--- a/apps/docs/content/docs/spec/llms-txt-extensions.mdx
+++ b/apps/docs/content/docs/spec/llms-txt-extensions.mdx
@@ -55,7 +55,7 @@ This section is novel to AEO and addresses a real failure mode: AI agents confla
 
 ### Markdown Twin URLs in llms.txt
 
-A conformant `llms.txt` SHOULD link to HTML URLs (not `.md` URLs) in its Section lists. AI agents can discover the markdown twin via the [`Link rel="alternate"` header](./discovery.md#1-link-relalternate-header-required) on the HTML response.
+A conformant `llms.txt` SHOULD link to HTML URLs (not `.md` URLs) in its Section lists. AI agents can discover the markdown twin via the [`Link rel="alternate"` header](/docs/spec/discovery#1-link-relalternate-header-required) on the HTML response.
 
 This is intentional: HTML URLs are stable, link-shareable, and conform to user expectations. The markdown is an alternate representation, not a separate resource.
 

--- a/apps/docs/scripts/sync-spec.mjs
+++ b/apps/docs/scripts/sync-spec.mjs
@@ -26,9 +26,12 @@ for (const name of readdirSync(specDir)) {
 
   let body = readFileSync(join(specDir, name), "utf8");
 
-  body = body.replace(/^# .+\n+/, "");
+  body = body.replace(/^# .+(?:\r?\n)+/, "");
 
-  body = body.replace(/\]\(\.\/([\w-]+)\.md\)/g, (_m, slug) => `](/docs/spec/${FILE_MAP[`${slug}.md`]?.slug ?? slug})`);
+  body = body.replace(
+    /\]\(\.\/([\w-]+)\.md(#[^)]+)?\)/g,
+    (_m, slug, hash = "") => `](/docs/spec/${FILE_MAP[`${slug}.md`]?.slug ?? slug}${hash})`,
+  );
 
   body = body.replace(/\.\.\/packages\/([\w-]+)/g, (_m, pkg) => `/docs/packages/${pkg}`);
   body = body.replace(/\.\.\/packages/g, "/docs/packages/core");


### PR DESCRIPTION
## Summary

Fix spec-to-docs link rewriting for relative Markdown links that include section anchors, while keeping heading removal stable across LF and CRLF files.

## Changes

- Preserve `#anchor` fragments when rewriting relative spec links.
- Support both LF and CRLF line endings when removing source headings.
- Regenerate the affected llms.txt extensions documentation.

## Type

- [x] Bug fix (non-breaking)
- [x] Docs / examples / tooling only

## Verification

- [x] `bun run build` passes — 22/22 tasks
- [x] `bun run test` passes — 24/24 tasks
- [x] `bun run typecheck` passes — 25/25 tasks
- [x] Docs production build passes — 86 static pages generated

## Changeset

Not required: no published package behavior or version is changed.